### PR TITLE
New generation. Validate Cassandra native filters

### DIFF
--- a/crossdata-examples/src/main/scala/com/stratio/crossdata/examples/CassandraExample.scala
+++ b/crossdata-examples/src/main/scala/com/stratio/crossdata/examples/CassandraExample.scala
@@ -17,7 +17,7 @@
 package com.stratio.crossdata.examples
 
 import org.apache.spark.sql.crossdata.XDContext
-import org.apache.spark.{SparkContext, SparkConf}
+import org.apache.spark.{SparkConf, SparkContext}
 
 sealed trait DefaultConstants {
   val Cluster = "Test Cluster"

--- a/crossdata-examples/src/main/scala/com/stratio/crossdata/examples/CassandraExample.scala
+++ b/crossdata-examples/src/main/scala/com/stratio/crossdata/examples/CassandraExample.scala
@@ -22,9 +22,9 @@ import org.apache.spark.{SparkConf, SparkContext}
 sealed trait DefaultConstants {
   val Cluster = "Test Cluster"
   //val Catalog = "highschool"
-  val Catalog = "report"
+  val Catalog = "cassandra_demo"
   //val Table = "students"
-  val Table = "cars"
+  val Table = "users"
   val CassandraHost = "127.0.0.1"
   val SourceProvider = "com.stratio.crossdata.sql.sources.cassandra"
   // Cassandra provider => org.apache.spark.sql.cassandra
@@ -42,10 +42,15 @@ object CassandraExample extends App with DefaultConstants {
     // scalastyle:off
     //xdContext.sql(s"SELECT comment as b FROM $Table WHERE comment = 1 AND id = 5").collect().foreach(print)
     //xdContext.sql(s"SELECT comment as b FROM $Table WHERE id = 1").collect().foreach(print)
-    xdContext.sql(s"SELECT *  FROM $Table ").collect().foreach(print)
+    //xdContext.sql(s"SELECT *  FROM $Table ").collect().foreach(print)
     //xdContext.sql(s"SELECT comment as b FROM $Table WHERE comment = 'A'").show(5)
     //xdContext.sql(s"SELECT comment as b FROM $Table WHERE id IN(1,2,3,4,5,6,7,8,9,10) limit 2").show(5)
-    xdContext.sql(s"SELECT id as b FROM $Table WHERE id IN(1,2,3,4,5,6,7,8,9,10) limit 2").show(5)
+    //xdContext.sql(s"SELECT brand as b FROM $Table WHERE id IN(1,2,3,4,5,6,7,8,9,10) limit 2").show(5)
+
+    //xdContext.sql(s"SELECT name as b FROM $Table WHERE email = 'name_1@domain.com' and age > 1 limit 7").show(5)
+
+    xdContext.sql(s"SELECT name as b FROM $Table WHERE age > 1 limit 7").show(5)
+
     // scalastyle:on
 
   }

--- a/crossdata-examples/src/main/scala/com/stratio/crossdata/examples/CassandraExample.scala
+++ b/crossdata-examples/src/main/scala/com/stratio/crossdata/examples/CassandraExample.scala
@@ -21,8 +21,10 @@ import org.apache.spark.{SparkContext, SparkConf}
 
 sealed trait DefaultConstants {
   val Cluster = "Test Cluster"
-  val Catalog = "highschool"
-  val Table = "students"
+  //val Catalog = "highschool"
+  val Catalog = "report"
+  //val Table = "students"
+  val Table = "cars"
   val CassandraHost = "127.0.0.1"
   val SourceProvider = "com.stratio.crossdata.sql.sources.cassandra"
   // Cassandra provider => org.apache.spark.sql.cassandra
@@ -40,9 +42,10 @@ object CassandraExample extends App with DefaultConstants {
     // scalastyle:off
     //xdContext.sql(s"SELECT comment as b FROM $Table WHERE comment = 1 AND id = 5").collect().foreach(print)
     //xdContext.sql(s"SELECT comment as b FROM $Table WHERE id = 1").collect().foreach(print)
-    //xdContext.sql(s"SELECT *  FROM $Table ").collect().foreach(print)
+    xdContext.sql(s"SELECT *  FROM $Table ").collect().foreach(print)
     //xdContext.sql(s"SELECT comment as b FROM $Table WHERE comment = 'A'").show(5)
-    xdContext.sql(s"SELECT comment as b FROM $Table WHERE id IN(1,2,3,4,5,6,7,8,9,10) limit 2").show(5)
+    //xdContext.sql(s"SELECT comment as b FROM $Table WHERE id IN(1,2,3,4,5,6,7,8,9,10) limit 2").show(5)
+    xdContext.sql(s"SELECT id as b FROM $Table WHERE id IN(1,2,3,4,5,6,7,8,9,10) limit 2").show(5)
     // scalastyle:on
 
   }


### PR DESCRIPTION
added a simple validation to cassandra filters to check if the filter is a cluster key column, then all columns of cluster key must appear in filters to execute in a native way, in other cases the execution will be through spark cluster