### PR TITLE
Cd856 new ddlsentences

### DIFF
--- a/crossdata-ng/src/main/scala/org/apache/spark/sql/crossdata/XDContext.scala
+++ b/crossdata-ng/src/main/scala/org/apache/spark/sql/crossdata/XDContext.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql.crossdata
 
 import java.util.concurrent.atomic.AtomicReference
 
+import org.apache.spark.sql.sources.crossdata.XDDdlParser
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.{Logging, SparkContext}
 
@@ -54,6 +55,8 @@ class XDContext(@transient val sc: SparkContext) extends SQLContext(sc) with Log
 
   catalog.open()
  */
+
+  protected[sql] override val ddlParser = new XDDdlParser(sqlParser.parse(_))
 
   override def sql(sqlText: String): DataFrame = {
     XDDataFrame(this, parseSql(sqlText))

--- a/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/XDDdlParser.scala
+++ b/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/XDDdlParser.scala
@@ -1,0 +1,29 @@
+package org.apache.spark.sql.sources.crossdata
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.sources.{DDLException, DDLParser}
+
+class XDDdlParser(parseQuery: String => LogicalPlan) extends DDLParser(parseQuery) {
+
+  protected val IMPORT = Keyword("IMPORT")
+  protected val CATALOG = Keyword("CATALOG")
+
+  override protected lazy val ddl: Parser[LogicalPlan] =
+    createTable | describeTable | refreshTable | importStart
+
+  protected lazy val importStart: Parser[LogicalPlan] =
+    (IMPORT ~> (CATALOG | (TABLE ~> tableIdentifier))) ~ (USING ~> className) ~  (OPTIONS ~> options).?  ^^ {
+      case "catalog" ~ provider ~ ops =>
+        ImportCatalogUsingWithOptions(provider.asInstanceOf[String], ops.getOrElse(Map.empty))
+      case other => ???
+    }
+
+  protected[sql] case class TableIdentifier(table: String, db: Option[String])
+
+  //Based on Spark 1.5 DDLParser's "tableIdentifier parser"
+  protected lazy val tableIdentifier: Parser[TableIdentifier] =
+    (ident <~ ".").? ~ ident ^^ {
+      case maybeDbName ~ tableName => TableIdentifier(tableName, maybeDbName)
+    }
+
+}

--- a/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
+++ b/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
@@ -1,0 +1,12 @@
+package org.apache.spark.sql.sources.crossdata
+
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.catalyst.expressions.Row
+import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
+import org.apache.spark.sql.execution.RunnableCommand
+
+
+private [crossdata] case class ImportCatalogUsingWithOptions(provider: String, opts: Map[String, String])
+  extends LogicalPlan with RunnableCommand {
+  override def run(sqlContext: SQLContext): Seq[Row] = ??? //TODO: Implement the command action
+}

--- a/crossdata-ng/src/test/scala/org/apache/spark/sql/crossdata/XDContextIT.scala
+++ b/crossdata-ng/src/test/scala/org/apache/spark/sql/crossdata/XDContextIT.scala
@@ -50,4 +50,10 @@ class XDContextIT extends SharedXDContextTest {
     dataframe shouldBe a[XDDataFrame]
   }
 
+  /* TODO: Complete this test once ImportCatalogUsingWithOptions#run method has been implemented
+  it must "import all tables from a catalog" in {
+    ctx.sql("IMPORT CATALOG USING dummypkg.dummyclass")
+  }
+  */
+
 }

--- a/crossdata-ng/src/test/scala/org/apache/spark/sql/sources/crossdata/XDDdlParserSpec.scala
+++ b/crossdata-ng/src/test/scala/org/apache/spark/sql/sources/crossdata/XDDdlParserSpec.scala
@@ -1,0 +1,36 @@
+package org.apache.spark.sql.sources.crossdata
+
+import org.scalatest.{Matchers, WordSpec}
+
+/**
+ * Created by pfperez on 17/09/15.
+ */
+class XDDdlParserSpec extends WordSpec with Matchers {
+
+  "A XDDlParser" should {
+    val parser = new XDDdlParser(_ => null)
+
+    """successfully parse an "IMPORT CATALOG" sentence into
+      |a ImportCatalogUsingWithOptions RunnableCommand """.stripMargin in {
+
+      val sentence =
+        """IMPORT CATALOG
+          | USING org.apache.dumypackage.dummyclass
+          | OPTIONS (
+          |   addr     "dummyaddr",
+          |   database "dummydb"
+          | )
+          | """.stripMargin
+
+      parser.parse(sentence) shouldBe ImportCatalogUsingWithOptions(
+        "org.apache.dumypackage.dummyclass",
+         Map(
+          "addr" -> "dummyaddr",
+          "database" -> "dummydb"
+         )
+      )
+    }
+
+  }
+
+}

--- a/crossdata-ng/src/test/scala/org/apache/spark/sql/sources/crossdata/XDDdlParserSpec.scala
+++ b/crossdata-ng/src/test/scala/org/apache/spark/sql/sources/crossdata/XDDdlParserSpec.scala
@@ -1,36 +1,72 @@
 package org.apache.spark.sql.sources.crossdata
-
+import com.stratio.crossdata.test.BaseXDTest
+import org.apache.spark.sql.sources.{RefreshTable, CreateTableUsing, DescribeCommand}
 import org.scalatest.{Matchers, WordSpec}
 
-/**
- * Created by pfperez on 17/09/15.
- */
-class XDDdlParserSpec extends WordSpec with Matchers {
+class XDDdlParserSpec extends BaseXDTest {
 
-  "A XDDlParser" should {
-    val parser = new XDDdlParser(_ => null)
+  val parser = new XDDdlParser(_ => null)
 
-    """successfully parse an "IMPORT CATALOG" sentence into
-      |a ImportCatalogUsingWithOptions RunnableCommand """.stripMargin in {
+  "A XDDlParser" should  """successfully parse an "IMPORT CATALOG" sentence into
+                           |a ImportCatalogUsingWithOptions RunnableCommand """.stripMargin in {
 
-      val sentence =
-        """IMPORT CATALOG
-          | USING org.apache.dumypackage.dummyclass
-          | OPTIONS (
-          |   addr     "dummyaddr",
-          |   database "dummydb"
-          | )
-          | """.stripMargin
+    val sentence =
+      """IMPORT CATALOG
+        | USING org.apache.dumypackage.dummyclass
+        | OPTIONS (
+        |   addr     "dummyaddr",
+        |   database "dummydb"
+        | )
+        | """.stripMargin
 
-      parser.parse(sentence) shouldBe ImportCatalogUsingWithOptions(
-        "org.apache.dumypackage.dummyclass",
-         Map(
-          "addr" -> "dummyaddr",
-          "database" -> "dummydb"
-         )
+    parser.parse(sentence) shouldBe ImportCatalogUsingWithOptions(
+      "org.apache.dumypackage.dummyclass",
+      Map(
+        "addr" -> "dummyaddr",
+        "database" -> "dummydb"
       )
-    }
+    )
 
   }
 
+  it should "generate an ImportCatalogUsingWithOptionsan with empty options map when they haven't been provided" in {
+
+    val sentence = "IMPORT CATALOG USING org.apache.dumypackage.dummyclass"
+    parser.parse(sentence) shouldBe ImportCatalogUsingWithOptions("org.apache.dumypackage.dummyclass", Map.empty)
+
+  }
+
+  //Sentences and expected values for SparkSQL core DDL
+  val rightSentences = List[(String, PartialFunction[Any, Unit])] (
+    ("""CREATE TEMPORARY TABLE words
+       |USING org.apache.spark.sql.cassandra
+       |OPTIONS (
+       |  table "words",
+       |  keyspace "test",
+       |  cluster "Test Cluster",
+       |  pushdown "true"
+       |)""".stripMargin,            { case _: CreateTableUsing => () } ),
+    ("REFRESH TABLE ddb.dummyTable", { case _: RefreshTable => ()     } ),
+    ("DESCRIBE ddb.dummyTable",      { case _: DescribeCommand => (); } )
+  )
+  for((sentence, expect) <- rightSentences)
+    it should s"keep parsing SparkSQL core DDL sentences: $sentence" in {
+      expect.lift(parser.parse(sentence)) should not be None
+    }
+
+  //Malformed sentences and their expectations
+  val wrongSentences =  List[String] (
+    "IMPORT TABLE dummy",
+    """IMPORT CATALOG
+      | OPTIONS (
+      |   addr     "dummyaddr",
+      |   database "dummydb"
+      | )
+      | """.stripMargin
+  )
+  wrongSentences foreach { sentence =>
+    it should s"fail when parsing wrong sentences: $sentence" in {
+      an [Exception] should be thrownBy parser.parse(sentence)
+    }
+  }
 }


### PR DESCRIPTION
This branch contains the changes that endow `XDContext` with a customized DDL parser which initially parses sentences matching the pattern: 

`IMPORT CATALOG USING <package. ... .subpackage.class> OPTIONS ( optname "value", ...)`

It remains to be completed the implementation of, the `RunnableCommand`, `ImportCatalogUsingWithOptions` with its functionality.