### PR TITLE
Cd856 action with provideriface

### DIFF
--- a/crossdata-cassandra/src/main/scala/org/apache/spark/sql/cassandra/CassandraXDSourceRelation.scala
+++ b/crossdata-cassandra/src/main/scala/org/apache/spark/sql/cassandra/CassandraXDSourceRelation.scala
@@ -31,7 +31,6 @@ import com.stratio.crossdata.sql.sources.NativeScan
 import com.stratio.crossdata.sql.sources.cassandra.CassandraQueryProcessor
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.cassandra.DataTypeConverter._
-import org.apache.spark.sql.catalyst.expressions.Alias
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.sources._

--- a/crossdata-cassandra/src/test/scala/com/stratio/crossdata/sql/sources/cassandra/CassandraConnectorIT.scala
+++ b/crossdata-cassandra/src/test/scala/com/stratio/crossdata/sql/sources/cassandra/CassandraConnectorIT.scala
@@ -130,9 +130,9 @@ class CassandraConnectorIT extends CassandraWithSharedContext {
 
   // TODO test filter on PKs (=) and CKs(any) (right -> left)
 
-  // CATALOG OPERATIONS
+  // IMPORT OPERATIONS
 
-  it should "import all tables from a catalog" in {
+  it should "import all tables from a keyspace" in {
     assumeEnvironmentIsUpAndRunning
 
     def tableCountInHighschool: Long = ctx.sql("SHOW TABLES").count
@@ -140,7 +140,7 @@ class CassandraConnectorIT extends CassandraWithSharedContext {
 
     val importQuery =
       s"""
-          |IMPORT CATALOG
+          |IMPORT TABLES
           |USING $SourceProvider
           |OPTIONS (
           | cluster "$ClusterName",
@@ -154,16 +154,16 @@ class CassandraConnectorIT extends CassandraWithSharedContext {
 
   }
 
-  val wrongImportCatalogSentences = List(
+  val wrongImportTablesSentences = List(
     s"""
-       |IMPORT CATALOG
+       |IMPORT TABLES
        |USING $SourceProvider
        |OPTIONS (
        | cluster "$ClusterName"
        |)
     """.stripMargin,
     s"""
-       |IMPORT CATALOG
+       |IMPORT TABLES
        |USING $SourceProvider
        |OPTIONS (
        | spark_cassandra_connection_host '$CassandraHost'
@@ -171,8 +171,8 @@ class CassandraConnectorIT extends CassandraWithSharedContext {
      """.stripMargin
   )
 
-  wrongImportCatalogSentences.take(1) foreach { sentence =>
-    it should s"not import catalogs for sentences lacking mandatory options: $sentence" in {
+  wrongImportTablesSentences.take(1) foreach { sentence =>
+    it should s"not import tables for sentences lacking mandatory options: $sentence" in {
       assumeEnvironmentIsUpAndRunning
       an [Exception] shouldBe thrownBy(ctx.sql(sentence))
     }

--- a/crossdata-cassandra/src/test/scala/com/stratio/crossdata/sql/sources/cassandra/CassandraConnectorIT.scala
+++ b/crossdata-cassandra/src/test/scala/com/stratio/crossdata/sql/sources/cassandra/CassandraConnectorIT.scala
@@ -152,7 +152,30 @@ class CassandraConnectorIT extends CassandraWithSharedContext {
 
     tableCountInHighschool shouldBe 3
 
+  }
 
+  val wrongImportCatalogSentences = List(
+    s"""
+       |IMPORT CATALOG
+       |USING $SourceProvider
+       |OPTIONS (
+       | cluster "$ClusterName"
+       |)
+    """.stripMargin,
+    s"""
+       |IMPORT CATALOG
+       |USING $SourceProvider
+       |OPTIONS (
+       | spark_cassandra_connection_host '$CassandraHost'
+       |)
+     """.stripMargin
+  )
+
+  wrongImportCatalogSentences.take(1) foreach { sentence =>
+    it should s"not import catalogs for sentences lacking mandatory options: $sentence" in {
+      assumeEnvironmentIsUpAndRunning
+      an [Exception] shouldBe thrownBy(ctx.sql(sentence))
+    }
   }
 
 }

--- a/crossdata-cassandra/src/test/scala/com/stratio/crossdata/sql/sources/cassandra/CassandraConnectorIT.scala
+++ b/crossdata-cassandra/src/test/scala/com/stratio/crossdata/sql/sources/cassandra/CassandraConnectorIT.scala
@@ -130,6 +130,31 @@ class CassandraConnectorIT extends CassandraWithSharedContext {
 
   // TODO test filter on PKs (=) and CKs(any) (right -> left)
 
+  // CATALOG OPERATIONS
+
+  it should "import all tables from a catalog" in {
+    assumeEnvironmentIsUpAndRunning
+
+    def tableCountInHighschool: Long = ctx.sql("SHOW TABLES").count
+    tableCountInHighschool shouldBe 1
+
+    val importQuery =
+      s"""
+          |IMPORT CATALOG
+          |USING $SourceProvider
+          |OPTIONS (
+          | cluster "$ClusterName",
+          | spark_cassandra_connection_host '$CassandraHost'
+          |)
+      """.stripMargin
+
+    ctx.sql(importQuery)
+
+    tableCountInHighschool shouldBe 3
+
+
+  }
+
 }
 
 

--- a/crossdata-cassandra/src/test/scala/com/stratio/crossdata/sql/sources/cassandra/CassandraWithSharedContext.scala
+++ b/crossdata-cassandra/src/test/scala/com/stratio/crossdata/sql/sources/cassandra/CassandraWithSharedContext.scala
@@ -94,6 +94,10 @@ trait CassandraWithSharedContext extends SharedXDContextTest with CassandraDefau
       session.execute("INSERT INTO " + Catalog + "." + Table + " (id, age, comment, enrolled) VALUES " +
         "(" + a + ", " + (10 + a) + ", 'Comment " + a + "', " + (a % 2 == 0) + ")")
     }
+
+    //This crates a new table in the keyspace which will not be initially registered at the Spark
+    session.execute(s"CREATE TABLE $Catalog.$UnregisteredTable (id int, age int, comment text, name text, PRIMARY KEY ((id), age, comment))")
+
   }
 
   private def cleanTestData(session: Session): Unit = {
@@ -115,6 +119,7 @@ sealed trait CassandraDefaultTestConstants {
   val ClusterName = "Test Cluster"
   val Catalog = "highschool"
   val Table = "students"
+  val UnregisteredTable = "teachers"
   val CassandraHost = "127.0.0.1"
   val SourceProvider = "com.stratio.crossdata.sql.sources.cassandra"
 }

--- a/crossdata-ng/src/main/scala/com/stratio/crossdata/sql/sources/interfaces.scala
+++ b/crossdata-ng/src/main/scala/com/stratio/crossdata/sql/sources/interfaces.scala
@@ -19,6 +19,7 @@ package com.stratio.crossdata.sql.sources
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.types.StructType
 
 /**
  * A BaseRelation that can execute the whole logical plan without running the query
@@ -43,4 +44,25 @@ sealed trait PushDownable {
    * @return whether the logical step within the entire logical plan is supported
    */
   def isSupported(logicalStep: LogicalPlan, wholeLogicalPlan: LogicalPlan): Boolean
+}
+
+/**
+ * Interface including data source operations for listing and describing tables
+ * at a data source.
+ *
+ */
+@DeveloperApi
+trait TableInventory {
+
+  import TableInventory._
+
+  def inventoryItem2optionsMap(item: Table): Map[String, String]
+
+  def listTables: Seq[Table]
+  //TODO: Add operation for describing a concrete table.
+}
+
+object TableInventory {
+  //Table description
+  case class Table(val database: String, val tableName: String, schema: StructType)
 }

--- a/crossdata-ng/src/main/scala/com/stratio/crossdata/sql/sources/interfaces.scala
+++ b/crossdata-ng/src/main/scala/com/stratio/crossdata/sql/sources/interfaces.scala
@@ -65,10 +65,25 @@ trait TableInventory {
    */
   def generateConnectorOpts(item: Table, userOpts: Map[String, String] = Map.empty): Map[String, String]
 
+  /**
+   * Overriding this function allows tables import filtering. e.g: Avoiding system tables.
+   *
+   * @param table Table description case class instance
+   * @return `true` if the table shall be imported, `false` otherwise
+   */
   def exclusionFilter(table: TableInventory.Table) = true
 
+  /**
+   *
+   * @param context SQLContext at which the command will be executed.
+   * @param options SQL Sentence user options
+   * @return A list of tables descriptions extracted from the datasource using a connector.0
+   */
   def listTables(context: SQLContext, options: Map[String, String]): Seq[Table]
+
+
   //TODO: Add operation for describing a concrete table.
+  //def fetchTableDescription(name: String, options: Map[String, String]): Table
 }
 
 object TableInventory {

--- a/crossdata-ng/src/main/scala/com/stratio/crossdata/sql/sources/interfaces.scala
+++ b/crossdata-ng/src/main/scala/com/stratio/crossdata/sql/sources/interfaces.scala
@@ -17,7 +17,7 @@
 package com.stratio.crossdata.sql.sources
 
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{SQLContext, Row}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.types.StructType
 
@@ -56,13 +56,19 @@ trait TableInventory {
 
   import TableInventory._
 
+  /**
+   *
+   * @param item Table description case class instance
+   * @return A concrete (for a given connector) translation of the high level table description
+   *         to a low-level option map.
+   */
   def inventoryItem2optionsMap(item: Table): Map[String, String]
 
-  def listTables: Seq[Table]
+  def listTables(context: SQLContext, options: Map[String, String]): Seq[Table]
   //TODO: Add operation for describing a concrete table.
 }
 
 object TableInventory {
   //Table description
-  case class Table(val database: String, val tableName: String, schema: StructType)
+  case class Table(database: String, tableName: String, clusterName: String, schema: StructType)
 }

--- a/crossdata-ng/src/main/scala/com/stratio/crossdata/sql/sources/interfaces.scala
+++ b/crossdata-ng/src/main/scala/com/stratio/crossdata/sql/sources/interfaces.scala
@@ -59,10 +59,13 @@ trait TableInventory {
   /**
    *
    * @param item Table description case class instance
+   * @param userOpts Options provided by the parsed sentence
    * @return A concrete (for a given connector) translation of the high level table description
    *         to a low-level option map.
    */
-  def inventoryItem2optionsMap(item: Table): Map[String, String]
+  def generateConnectorOpts(item: Table, userOpts: Map[String, String] = Map.empty): Map[String, String]
+
+  def exclusionFilter(table: TableInventory.Table) = true
 
   def listTables(context: SQLContext, options: Map[String, String]): Seq[Table]
   //TODO: Add operation for describing a concrete table.

--- a/crossdata-ng/src/main/scala/com/stratio/crossdata/sql/sources/interfaces.scala
+++ b/crossdata-ng/src/main/scala/com/stratio/crossdata/sql/sources/interfaces.scala
@@ -71,7 +71,7 @@ trait TableInventory {
    * @param table Table description case class instance
    * @return `true` if the table shall be imported, `false` otherwise
    */
-  def exclusionFilter(table: TableInventory.Table) = true
+  def exclusionFilter(table: TableInventory.Table): Boolean = true
 
   /**
    *
@@ -88,5 +88,5 @@ trait TableInventory {
 
 object TableInventory {
   //Table description
-  case class Table(database: String, tableName: String, clusterName: String, schema: StructType)
+  case class Table(tableName: String, database: Option[String] = None, schema: Option[StructType] = None)
 }

--- a/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/XDDdlParser.scala
+++ b/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/XDDdlParser.scala
@@ -3,8 +3,6 @@ package org.apache.spark.sql.sources.crossdata
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.sources.{DDLException, DDLParser}
 
-import scala.sys
-
 class XDDdlParser(parseQuery: String => LogicalPlan) extends DDLParser(parseQuery) {
 
   protected val IMPORT = Keyword("IMPORT")

--- a/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/XDDdlParser.scala
+++ b/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/XDDdlParser.scala
@@ -14,10 +14,7 @@ class XDDdlParser(parseQuery: String => LogicalPlan) extends DDLParser(parseQuer
   protected lazy val importStart: Parser[LogicalPlan] =
     (IMPORT ~> (CATALOG | (TABLE ~> tableIdentifier))) ~ (USING ~> className) ~  (OPTIONS ~> options).?  ^^ {
       case "catalog" ~ provider ~ ops =>
-        val mops = ops.getOrElse(Map.empty)
-        for(opName <- "cluster"::"spark_cassandra_connection_host"::Nil; if(!mops.contains(opName)))
-          sys.error(s"""Option "$opName" is mandatory for IMPORT CATALOG""")
-        ImportCatalogUsingWithOptions(provider.asInstanceOf[String], mops)
+        ImportCatalogUsingWithOptions(provider.asInstanceOf[String], ops.getOrElse(Map.empty))
       case other => ???
     }
 

--- a/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/XDDdlParser.scala
+++ b/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/XDDdlParser.scala
@@ -6,16 +6,15 @@ import org.apache.spark.sql.sources.{DDLException, DDLParser}
 class XDDdlParser(parseQuery: String => LogicalPlan) extends DDLParser(parseQuery) {
 
   protected val IMPORT = Keyword("IMPORT")
-  protected val CATALOG = Keyword("CATALOG")
+  protected val TABLES = Keyword("TABLES")
 
   override protected lazy val ddl: Parser[LogicalPlan] =
     createTable | describeTable | refreshTable | importStart
 
   protected lazy val importStart: Parser[LogicalPlan] =
-    (IMPORT ~> (CATALOG | (TABLE ~> tableIdentifier))) ~ (USING ~> className) ~  (OPTIONS ~> options).?  ^^ {
-      case "catalog" ~ provider ~ ops =>
-        ImportCatalogUsingWithOptions(provider.asInstanceOf[String], ops.getOrElse(Map.empty))
-      case other => ???
+    IMPORT ~> TABLES ~> (USING ~> className) ~ (OPTIONS ~> options).? ^^ {
+      case provider ~ ops =>
+        ImportTablesUsingWithOptions(provider.asInstanceOf[String], ops.getOrElse(Map.empty))
     }
 
   protected[sql] case class TableIdentifier(table: String, db: Option[String])

--- a/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
+++ b/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
@@ -24,7 +24,7 @@ private [crossdata] case class ImportCatalogUsingWithOptions(provider: String, o
     //Register the source tables in the catalog
     for(
       t: TableInventory.Table <- tables;
-      tableid = t.database::t.tableName::Nil;
+      tableid = t.database.toList :+ t.tableName;
       doExist = sqlContext.catalog.tableExists(tableid);
       if(inventoryRelation.exclusionFilter(t) && {
         if(doExist) log.info(s"IMPORT CATALOG omitted already registered table: ${tableid mkString "."}")

--- a/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
+++ b/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.execution.RunnableCommand
 import org.apache.spark.sql.sources.{RelationProvider, LogicalRelation, ResolvedDataSource}
 
 
-private [crossdata] case class ImportCatalogUsingWithOptions(provider: String, opts: Map[String, String])
+private [crossdata] case class ImportTablesUsingWithOptions(provider: String, opts: Map[String, String])
   extends LogicalPlan with RunnableCommand {
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
@@ -27,7 +27,7 @@ private [crossdata] case class ImportCatalogUsingWithOptions(provider: String, o
       tableid = t.database.toList :+ t.tableName;
       doExist = sqlContext.catalog.tableExists(tableid);
       if(inventoryRelation.exclusionFilter(t) && {
-        if(doExist) log.info(s"IMPORT CATALOG omitted already registered table: ${tableid mkString "."}")
+        if(doExist) log.info(s"IMPORT TABLE omitted already registered table: ${tableid mkString "."}")
         !doExist
       })
     ) sqlContext.

--- a/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
+++ b/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
@@ -1,37 +1,25 @@
 package org.apache.spark.sql.sources.crossdata
 
-import com.google.protobuf.WireFormat.FieldType
 import com.stratio.crossdata.sql.sources.TableInventory
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.expressions.Row
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.RunnableCommand
 import org.apache.spark.sql.sources.{RelationProvider, LogicalRelation, ResolvedDataSource}
-import org.apache.spark.sql.types.{StructField, StructType}
 
 
 private [crossdata] case class ImportCatalogUsingWithOptions(provider: String, opts: Map[String, String])
   extends LogicalPlan with RunnableCommand {
 
-  //TODO: Implement tables description persistence
-  protected def persistenceStep(tables: Seq[TableInventory.Table]): Unit = ()
-
   override def run(sqlContext: SQLContext): Seq[Row] = {
     //Get a reference to the inventory relation.
     val resolved = ResolvedDataSource.lookupDataSource(provider).newInstance()
-    /*ResolvedDataSource(sqlContext, Some(StructType(Array.empty[StructField])), Array.empty[String],
-      provider,
-      opts.updated("table","").updated("keyspace", ""))
-    //opts.updated("table","").updated("keyspace", "")
-    */
+
     val inventoryRelation = resolved.asInstanceOf[TableInventory] //As inventory provider
-    //TODO: Check error management. It may happen that the provided datasource doesn't support inventory
     val providerRelation = resolved.asInstanceOf[RelationProvider] //As relation provider
 
-    //Obtain the list of tables and persist it (if persistence implemented)
-    //TODO: Check error management. It may happen that a cluster name has not been provided
+    //Obtains the list of tables and persist it (if persistence implemented)
     val tables = inventoryRelation.listTables(sqlContext, opts)
-    persistenceStep(tables)
 
     //Register the source tables in the catalog
     for(
@@ -42,8 +30,7 @@ private [crossdata] case class ImportCatalogUsingWithOptions(provider: String, o
         if(doExist) log.info(s"IMPORT CATALOG omitted already registered table: ${tableid mkString "."}")
         !doExist
       })
-    ) {
-      sqlContext.
+    ) sqlContext.
         catalog.registerTable(
           tableid,
           LogicalRelation(providerRelation.createRelation(
@@ -51,7 +38,6 @@ private [crossdata] case class ImportCatalogUsingWithOptions(provider: String, o
             inventoryRelation.generateConnectorOpts(t, opts))
           )
         )
-    }
     Seq.empty
   }
 }

--- a/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
+++ b/crossdata-ng/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
@@ -1,12 +1,41 @@
 package org.apache.spark.sql.sources.crossdata
 
+import com.stratio.crossdata.sql.sources.TableInventory
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.expressions.Row
-import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.RunnableCommand
+import org.apache.spark.sql.sources.{RelationProvider, LogicalRelation, ResolvedDataSource}
 
 
 private [crossdata] case class ImportCatalogUsingWithOptions(provider: String, opts: Map[String, String])
   extends LogicalPlan with RunnableCommand {
-  override def run(sqlContext: SQLContext): Seq[Row] = ??? //TODO: Implement the command action
+
+  //TODO: Implement tables description persistence
+  protected def persistenceStep(tables: Seq[TableInventory.Table]): Unit = ()
+
+  override def run(sqlContext: SQLContext): Seq[Row] = {
+
+    //Get a reference to the inventory relation.
+    val resolved = ResolvedDataSource(sqlContext, None, Array.empty[String], provider, opts)
+    val inventoryRelation = resolved.relation.asInstanceOf[TableInventory] //As inventory provider
+    val providerRelation = resolved.relation.asInstanceOf[RelationProvider] //As relation provider
+
+    //Obtain the list of tables and persist it (if persistence implemented)
+    val tables = inventoryRelation.listTables
+    persistenceStep(tables)
+
+    //Register the source tables in the catalog
+    tables foreach { t =>
+      sqlContext.
+        catalog.registerTable(
+          t.tableName::Nil,
+          LogicalRelation(providerRelation.createRelation(
+            sqlContext,
+            inventoryRelation.inventoryItem2optionsMap(t))
+          )
+        )
+    }
+    Seq.empty
+  }
 }

--- a/crossdata-ng/src/test/scala/org/apache/spark/sql/crossdata/XDContextIT.scala
+++ b/crossdata-ng/src/test/scala/org/apache/spark/sql/crossdata/XDContextIT.scala
@@ -50,10 +50,4 @@ class XDContextIT extends SharedXDContextTest {
     dataframe shouldBe a[XDDataFrame]
   }
 
-  /* TODO: Complete this test once ImportCatalogUsingWithOptions#run method has been implemented
-  it must "import all tables from a catalog" in {
-    ctx.sql("IMPORT CATALOG USING dummypkg.dummyclass")
-  }
-  */
-
 }

--- a/crossdata-ng/src/test/scala/org/apache/spark/sql/sources/crossdata/XDDdlParserSpec.scala
+++ b/crossdata-ng/src/test/scala/org/apache/spark/sql/sources/crossdata/XDDdlParserSpec.scala
@@ -7,11 +7,11 @@ class XDDdlParserSpec extends BaseXDTest {
 
   val parser = new XDDdlParser(_ => null)
 
-  "A XDDlParser" should  """successfully parse an "IMPORT CATALOG" sentence into
-                           |a ImportCatalogUsingWithOptions RunnableCommand """.stripMargin in {
+  "A XDDlParser" should  """successfully parse an "IMPORT TABLES" sentence into
+                           |a ImportTablesUsingWithOptions RunnableCommand """.stripMargin in {
 
     val sentence =
-      """IMPORT CATALOG
+      """IMPORT TABLES
         | USING org.apache.dumypackage.dummyclass
         | OPTIONS (
         |   addr     "dummyaddr",
@@ -19,20 +19,20 @@ class XDDdlParserSpec extends BaseXDTest {
         | )
         | """.stripMargin
 
-    parser.parse(sentence) shouldBe ImportCatalogUsingWithOptions(
+    parser.parse(sentence) shouldBe ImportTablesUsingWithOptions(
       "org.apache.dumypackage.dummyclass",
       Map(
-        "addr" -> "dummyaddr",
+        "addr"     -> "dummyaddr",
         "database" -> "dummydb"
       )
     )
 
   }
 
-  it should "generate an ImportCatalogUsingWithOptionsan with empty options map when they haven't been provided" in {
+  it should "generate an ImportCatalogUsingWithOptions with empty options map when they haven't been provided" in {
 
-    val sentence = "IMPORT CATALOG USING org.apache.dumypackage.dummyclass"
-    parser.parse(sentence) shouldBe ImportCatalogUsingWithOptions("org.apache.dumypackage.dummyclass", Map.empty)
+    val sentence = "IMPORT TABLES USING org.apache.dumypackage.dummyclass"
+    parser.parse(sentence) shouldBe ImportTablesUsingWithOptions("org.apache.dumypackage.dummyclass", Map.empty)
 
   }
 
@@ -56,8 +56,8 @@ class XDDdlParserSpec extends BaseXDTest {
 
   //Malformed sentences and their expectations
   val wrongSentences =  List[String] (
-    "IMPORT TABLE dummy",
-    """IMPORT CATALOG
+    "IMPORT TABLES",
+    """IMPORT TABLES
       | OPTIONS (
       |   addr     "dummyaddr",
       |   database "dummydb"

--- a/doc/src/site/sphinx/GrammarExp.rst
+++ b/doc/src/site/sphinx/GrammarExp.rst
@@ -82,10 +82,10 @@ IMPORT TABLES USING \<provider\> OPTIONS '(' (\<property\>',)\+'\<property\> ')'
 Example:
 
     IMPORT TABLES
-    USING $SourceProvider
+    USING com.stratio.crossdata.sql.sources.cassandra
     OPTIONS (
         cluster "Test Cluster",
-        spark_cassandra_connection_host 'com.stratio.crossdata.sql.sources.cassandra'
+        spark_cassandra_connection_host '127.0.0.1'
     )
 
 

--- a/doc/src/site/sphinx/GrammarExp.rst
+++ b/doc/src/site/sphinx/GrammarExp.rst
@@ -1,0 +1,92 @@
+CROSSDATA Expanded Grammar
+**************************
+
+Notes
+=======
+
+-   In general, a quoted (single or double) string refers to a literal
+    string whereas a string without quotation marks refers to a column
+    name.
+
+Example:
+
+    -   Column name:
+        -   total
+        -   myTable.total
+        -   myCatalog.myTable.total
+    -   Literal:
+        -   “Madrid”
+        -   ‘California'
+        -   “New York City”
+
+-   This expansion is under intense development so supported sentences set is expected to
+    rapidly grow.
+
+Introduction
+============
+
+        This document describes the standard SparkSQL grammar expansion provided by CROSSDATA.
+that means that any SQL sentences accepted by SparkSQL will be compatible with CROSSDATA.
+
+        Through the following lines you will find a description of those sentences provided by CROSSDATA which
+are not supported by Spark.
+
+
+Expansion main features
+=======================
+
+-   100% SparkSQL compatible.
+-   Added new table import capabilities:
+        -   `IMPORT CATALOG`: Catalog registration of every single table existing accessible by a concrete provider.
+
+Statements
+----------
+
+The language supports the following set of operations based on the SQL
+language.
+
+        The following elements are defined as:
+
+-   Identifier: Used to identify providers and, databases and tables.
+    An identifier is a token matching the regular expression
+    ([a-zA-Z0-9\_]+.)*[a-zA-Z0-9\_]+
+-   Values: A value is a text representation of any of the supported
+    data types.
+
+        The following non-terminal symbols appear in the grammar:
+
+-   \<simple\_identifier\> ::= LETTER (LETTER | DIGIT | '\_')\*
+-   \<identifier\> ::= (\<simple\_identifier\>'.')\*\<simple\_identifier\>
+-   \<literal\> ::= “ (\~”)\* ” | ‘ (\~')\* '
+-   \<provider\> ::= \<identifier\>
+-   \<database\> ::= \<simple\_identifier\>
+-   \<tablename\> ::= \<identifier\>
+-   \<property\> ::= \<identifier\> ' '\+ ( \<literal\> | \<constant\> )
+-   \<data-types\> = TEXT | BIGINT | INT | DOUBLE | FLOAT | BOOLEAN
+
+Supported types
+---------------
+
+-   TEXT
+-   VARCHAR
+-   BIGINT
+-   INT
+-   DOUBLE
+-   FLOAT
+-   BOOLEAN
+
+IMPORT TABLES
+-------------
+IMPORT TABLES USING \<provider\> OPTIONS '(' (\<property\>',)\+'\<property\> ')'
+
+Example:
+
+.. code-block:: scala
+    IMPORT TABLES
+    USING $SourceProvider
+    OPTIONS (
+        cluster "Test Cluster",
+        spark_cassandra_connection_host 'com.stratio.crossdata.sql.sources.cassandra'
+    )
+
+

--- a/doc/src/site/sphinx/GrammarExp.rst
+++ b/doc/src/site/sphinx/GrammarExp.rst
@@ -81,7 +81,6 @@ IMPORT TABLES USING \<provider\> OPTIONS '(' (\<property\>',)\+'\<property\> ')'
 
 Example:
 
-.. code-block:: scala
     IMPORT TABLES
     USING $SourceProvider
     OPTIONS (

--- a/doc/src/site/sphinx/GrammarExp.rst
+++ b/doc/src/site/sphinx/GrammarExp.rst
@@ -1,27 +1,6 @@
 CROSSDATA Expanded Grammar
 **************************
 
-Notes
-=======
-
--   In general, a quoted (single or double) string refers to a literal
-    string whereas a string without quotation marks refers to a column
-    name.
-
-Example:
-
-    -   Column name:
-        -   total
-        -   myTable.total
-        -   myCatalog.myTable.total
-    -   Literal:
-        -   “Madrid”
-        -   ‘California'
-        -   “New York City”
-
--   This expansion is under intense development so supported sentences set is expected to
-    rapidly grow.
-
 Introduction
 ============
 
@@ -37,7 +16,7 @@ Expansion main features
 
 -   100% SparkSQL compatible.
 -   Added new table import capabilities:
-        -   `IMPORT CATALOG`: Catalog registration of every single table existing accessible by a concrete provider.
+        -   `IMPORT TABLES`: Catalog registration of every single table existing accessible by a concrete provider.
 
 Statements
 ----------
@@ -62,18 +41,11 @@ language.
 -   \<database\> ::= \<simple\_identifier\>
 -   \<tablename\> ::= \<identifier\>
 -   \<property\> ::= \<identifier\> ' '\+ ( \<literal\> | \<constant\> )
--   \<data-types\> = TEXT | BIGINT | INT | DOUBLE | FLOAT | BOOLEAN
 
 Supported types
 ---------------
 
--   TEXT
--   VARCHAR
--   BIGINT
--   INT
--   DOUBLE
--   FLOAT
--   BOOLEAN
+Those supported by SparkSQL
 
 IMPORT TABLES
 -------------

--- a/doc/src/site/sphinx/about.rst
+++ b/doc/src/site/sphinx/about.rst
@@ -40,7 +40,7 @@ You can also find help in https://groups.google.com/forum/#!forum/crossdata-user
 Grammar
 =======
 
-TODO
+Crossdata implements the standard SparkSQL grammar plus an expansion described `at <doc/src/site/sphinx/GrammarExp.rst>`
 
 
 Getting started


### PR DESCRIPTION
This pull request includes the implementation of the already recognized `IMPORT CATALOG` sentence for the C* connector.

It also provides with interfaces and examples for new implementations of tables and catalogs imports from any compatible connector. Any new relation being able of exploring datasources schemes should implement the `TableInventory` interface.