### PR TITLE
[CROSSDATA-76] [MongoDB] Fix queries with LIMIT 0

### DIFF
--- a/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoConnectorIT.scala
+++ b/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoConnectorIT.scala
@@ -125,6 +125,12 @@ class MongoConnectorIT extends MongoWithSharedContext {
     result should have length 2
   }
 
+  it should "execute natively a query with LIMIT 0" in {
+    assumeEnvironmentIsUpAndRunning
+    val result = sql(s"SELECT * FROM $Collection LIMIT 0").collect(Native)
+    result should have length 0
+  }
+
 
   // NOT SUPPORTED => JOIN
   it should "not execute natively a (SELECT * ...  ORDER BY _ )" in {


### PR DESCRIPTION
The same semantic should be applied for all connectors. So, although a limit 0 in MongoDB returns all the rows we should return no rows, 