### PR TITLE
[CROSSDATA-86] [CORE] Fix critical bug: persisted options didn't include generated opts

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/sources/crossdata/ddl.scala
@@ -24,38 +24,42 @@ import org.apache.spark.sql.sources.RelationProvider
 import org.apache.spark.sql.{Row, SQLContext}
 
 
-private [crossdata] case class ImportTablesUsingWithOptions(provider: String, opts: Map[String, String])
+private [crossdata] case class ImportTablesUsingWithOptions(datasource: String, opts: Map[String, String])
   extends LogicalPlan with RunnableCommand {
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
-    //Get a reference to the inventory relation.
-    val resolved = ResolvedDataSource.lookupDataSource(provider).newInstance()
 
-    val inventoryRelation = resolved.asInstanceOf[TableInventory] //As inventory provider
-    val providerRelation = resolved.asInstanceOf[RelationProvider] //As relation provider
+    def tableExists(tableId: List[String]): Boolean = {
+      val doExist = sqlContext.catalog.tableExists(tableId)
+      if (doExist) log.info(s"IMPORT TABLE omitted already registered table: ${tableId mkString "."}")
+      doExist
+    }
+
+    def persistTable(t: TableInventory.Table, tableInventory: TableInventory, relationProvider: RelationProvider) = {
+      val connectorOpts = tableInventory.generateConnectorOpts(t, opts)
+
+      sqlContext.catalog.asInstanceOf[XDCatalog].persistTable(
+        CrossdataTable(t.tableName, t.database, t.schema, datasource, Array.empty[String], connectorOpts),
+        Option(LogicalRelation(relationProvider.createRelation(sqlContext, connectorOpts)))
+      )
+    }
+
+    //Get a reference to the inventory relation.
+    val resolved = ResolvedDataSource.lookupDataSource(datasource).newInstance()
+
+    val inventoryRelation = resolved.asInstanceOf[TableInventory]
+    val relationProvider = resolved.asInstanceOf[RelationProvider]
 
     //Obtains the list of tables and persist it (if persistence implemented)
     val tables = inventoryRelation.listTables(sqlContext, opts)
 
-    //Register the source tables in the catalog
-    for(
-      t: TableInventory.Table <- tables;
-      //TODO: WARNING: The change described in the comment below should be done ASAP!
-      //TODO: Recover this `t.database.toList :+ t.tableName` when XDCatalog is ready;
-      tableid = s"`${(t.database.toList :+ t.tableName) mkString "."}`"::Nil;
-      if(inventoryRelation.exclusionFilter(t) && {
-        val doExist = sqlContext.catalog.tableExists(tableid);
-        if(doExist) log.info(s"IMPORT TABLE omitted already registered table: ${tableid mkString "."}")
-        !doExist
-      })
-    ) sqlContext.
-        catalog.asInstanceOf[XDCatalog].persistTable(
-        CrossdataTable(t.tableName, t.database,  t.schema, provider,  Array.empty[String], opts),
-          Option(LogicalRelation(providerRelation.createRelation(
-            sqlContext,
-            inventoryRelation.generateConnectorOpts(t, opts)))
-          )
-        )
+    for {
+      t: TableInventory.Table <- tables
+      tableid = s"`${(t.database.toList :+ t.tableName) mkString "."}`" :: Nil
+      if inventoryRelation.exclusionFilter(t) && !tableExists(tableid)
+    } persistTable(t, inventoryRelation, relationProvider)
     Seq.empty
   }
+
+
 }


### PR DESCRIPTION
Persisted options didn't include generated opts when importing tables