### PR TITLE
Full flattened columns

### DIFF
--- a/common/src/main/scala/com/stratio/crossdata/common/Messages.scala
+++ b/common/src/main/scala/com/stratio/crossdata/common/Messages.scala
@@ -20,9 +20,9 @@ import java.util.UUID
 
 import org.apache.spark.sql.Row
 
-case class SQLCommand(query: String, queryId: UUID = UUID.randomUUID())
+case class SQLCommand(query: String, queryId: UUID = UUID.randomUUID(), retrieveColumnNames: Boolean = false)
 
-trait SQLResult extends Serializable{
+trait SQLResult extends Serializable {
   val queryId: UUID
   def resultSet: Array[Row]
   def hasError: Boolean

--- a/common/src/main/scala/com/stratio/crossdata/common/Messages.scala
+++ b/common/src/main/scala/com/stratio/crossdata/common/Messages.scala
@@ -20,6 +20,7 @@ import java.util.UUID
 
 import org.apache.spark.sql.Row
 
+//TODO: Remove `retrieveColumnNames` when a better alternative to PR#257 has been found
 case class SQLCommand(query: String, queryId: UUID = UUID.randomUUID(), retrieveColumnNames: Boolean = false)
 
 trait SQLResult extends Serializable {

--- a/common/src/main/scala/com/stratio/crossdata/common/result/SQLResult.scala
+++ b/common/src/main/scala/com/stratio/crossdata/common/result/SQLResult.scala
@@ -29,6 +29,7 @@ case class SuccessfulQueryResult(queryId: UUID, result: Array[Row], schema: Stru
 
 }
 
+//TODO: Remove `SuccessfulQueryAnnotatedResult` case class when a better alternative to PR#257 has been found
 case class SuccessfulQueryAnnotatedResult(queryId: UUID, result: Array[Row], schema: StructType, colNames: Seq[String]
                                          ) extends SQLResult {
   require(result.length == colNames.length)

--- a/common/src/main/scala/com/stratio/crossdata/common/result/SQLResult.scala
+++ b/common/src/main/scala/com/stratio/crossdata/common/result/SQLResult.scala
@@ -29,6 +29,16 @@ case class SuccessfulQueryResult(queryId: UUID, result: Array[Row], schema: Stru
 
 }
 
+case class SuccessfulQueryAnnotatedResult(queryId: UUID, result: Array[Row], schema: StructType, colNames: Seq[String]
+                                         ) extends SQLResult {
+  require(result.length == colNames.length)
+
+  override val resultSet = result
+
+  def hasError = false
+
+}
+
 case class ErrorResult(queryId: UUID, message: String, cause: Option[Throwable] = None) extends SQLResult {
   override lazy val resultSet = cause.fold(throw new RuntimeException(message)) {
     throwable => throw new RuntimeException(message,throwable)

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
@@ -104,6 +104,7 @@ class XDDataFrame private[sql](@transient override val sqlContext: SQLContext,
     }
   }
 
+  //TODO: Remove `annotatedCollect` wrapper method when a better alternative to PR#257 has been found
   def annotatedCollect(): (Array[Row], Seq[String]) = {
     def flatSubFields(exp: Expression, prev: List[String] = Nil): List[String] = exp match {
       case Alias(child, _) => flatSubFields(child)

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
@@ -104,6 +104,15 @@ class XDDataFrame private[sql](@transient override val sqlContext: SQLContext,
     }
   }
 
+  def annotatedCollect(): (Array[Row], Seq[String]) = {
+    val rows = collect()
+    val columnNames = {
+      val plan = queryExecution.optimizedPlan
+      Seq[String]() //TODO use `plan` to extract the flattened, dotted, columns names
+    }
+    (rows, columnNames)
+  }
+
   /**
    * Collect using an specific [[ExecutionType]]. Only for testing purpose so far.
    *

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/test/SharedXDContextTypesTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/test/SharedXDContextTypesTest.scala
@@ -64,6 +64,7 @@ trait SharedXDContextTypesTest extends SharedXDContextWithDataTest {
         ) typeCheck(dframe.collect(executionType).head(i))
       }
 
+    //TODO: Remove Multi-level column flat test when a better alternative to PR#257 has been found
     //Multi-level column flat test
     if(typesSet.map(_.colname) contains "structofstruct")
       it should "provide flattened column names through the `annotatedCollect` method" in {

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/test/SharedXDContextTypesTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/test/SharedXDContextTypesTest.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.crossdata.test
 import com.stratio.crossdata.test.BaseXDTest
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.crossdata.ExecutionType
+import org.apache.spark.sql.crossdata.{XDDataFrame, ExecutionType}
 import org.apache.spark.sql.crossdata.test.SharedXDContextWithDataTest.SparkTable
 
 /* Mix this trait in a type test class to get most of the type test done.
@@ -55,7 +55,6 @@ trait SharedXDContextTypesTest extends SharedXDContextWithDataTest {
   //Template: This is the template implementation and shouldn't be modified in any specific test
 
   def doTypesTest(datasourceName: String): Unit = {
-
     for(executionType <- ExecutionType.Spark::ExecutionType.Native::Nil)
       datasourceName should s"provide the right types for $executionType execution" in {
         val dframe = sql("SELECT " + typesSet.map(_.colname).mkString(", ") + s" FROM $dataTypesTableName")
@@ -65,6 +64,13 @@ trait SharedXDContextTypesTest extends SharedXDContextWithDataTest {
         ) typeCheck(dframe.collect(executionType).head(i))
       }
 
+    //Multi-level column flat test
+    if(typesSet.map(_.colname) contains "structofstruct")
+      it should "provide flattened column names through the `annotatedCollect` method" in {
+        val dataFrame = sql("SELECT structofstruct.struct1.structField1 FROM typesCheckTable")
+        val (_, colNames) = dataFrame.asInstanceOf[XDDataFrame].annotatedCollect()
+        colNames.head shouldBe "structofstruct.struct1.structField1"
+      }
   }
 
   abstract override def saveTestData: Unit = {

--- a/driver/src/main/scala/com/stratio/crossdata/driver/actor/ProxyActor.scala
+++ b/driver/src/main/scala/com/stratio/crossdata/driver/actor/ProxyActor.scala
@@ -36,7 +36,7 @@ class ProxyActor(clusterClientActor: ActorRef, driver: Driver) extends Actor {
   lazy val logger = Logger.getLogger(classOf[ProxyActor])
 
   override def receive: Receive = {
-    case sqlCommand@SQLCommand(query, _) =>
+    case sqlCommand@SQLCommand(query, _, _) =>
       clusterClientActor forward ClusterClient.Send(ProxyActor.ServerPath, sqlCommand, localAffinity = false)
       logger.debug(s"Send query $query")
 

--- a/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
@@ -55,6 +55,4 @@ class ServerActor(cluster: Cluster, xdContext: XDContext) extends Actor with Ser
 
   }
 
-  protected def queryCommand
-
 }

--- a/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
@@ -18,10 +18,10 @@ package com.stratio.crossdata.server.actors
 import akka.actor.{Actor, Props}
 import akka.cluster.Cluster
 import com.stratio.crossdata.common.SQLCommand
-import com.stratio.crossdata.common.result.{ErrorResult, SuccessfulQueryResult}
+import com.stratio.crossdata.common.result.{SuccessfulQueryAnnotatedResult, ErrorResult, SuccessfulQueryResult}
 import com.stratio.crossdata.server.config.ServerConfig
 import org.apache.log4j.Logger
-import org.apache.spark.sql.crossdata.XDContext
+import org.apache.spark.sql.crossdata.{XDDataFrame, XDContext}
 
 
 object ServerActor {
@@ -34,12 +34,15 @@ class ServerActor(cluster: Cluster, xdContext: XDContext) extends Actor with Ser
 
   def receive: Receive = {
 
-    case sqlCommand @ SQLCommand(query,_) =>
+    case sqlCommand @ SQLCommand(query, _, withColnames) =>
       logger.debug(s"Query received ${sqlCommand.queryId}: ${sqlCommand.query}. Actor ${self.path.toStringWithoutAddress}")
       try {
         val df = xdContext.sql(query)
-        val rows = df.collect()
-        sender ! SuccessfulQueryResult(sqlCommand.queryId, rows, df.schema)
+        val response = if(withColnames) {
+          val (rows, cols) = df.asInstanceOf[XDDataFrame].annotatedCollect()
+          SuccessfulQueryAnnotatedResult(sqlCommand.queryId, rows, df.schema, cols)
+        } else SuccessfulQueryResult(sqlCommand.queryId, df.collect(), df.schema)
+        sender ! response
       } catch {
         case e: Throwable => {
           logger.error(e.getMessage)
@@ -51,5 +54,7 @@ class ServerActor(cluster: Cluster, xdContext: XDContext) extends Actor with Ser
       logger.error(s"Something is going wrong!. Unknown message: $any")
 
   }
+
+  protected def queryCommand
 
 }

--- a/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
@@ -39,6 +39,7 @@ class ServerActor(cluster: Cluster, xdContext: XDContext) extends Actor with Ser
       try {
         val df = xdContext.sql(query)
         val response = if(withColnames) {
+          //TODO: Remove response differentiation when a better solution than PR#257 has been found
           val (rows, cols) = df.asInstanceOf[XDDataFrame].annotatedCollect()
           SuccessfulQueryAnnotatedResult(sqlCommand.queryId, rows, df.schema, cols)
         } else SuccessfulQueryResult(sqlCommand.queryId, df.collect(), df.schema)


### PR DESCRIPTION
Added an `annotatedCollect` method which wraps `XDDataFrame#collect` method to provide a list of fully annotated column names. e.g: `List("col.subfield.subsubfield")`