### PR TITLE
Flattened Collect

### DIFF
--- a/common/src/main/scala/com/stratio/crossdata/common/result/SQLResult.scala
+++ b/common/src/main/scala/com/stratio/crossdata/common/result/SQLResult.scala
@@ -29,15 +29,6 @@ case class SuccessfulQueryResult(queryId: UUID, result: Array[Row], schema: Stru
 
 }
 
-//TODO: Remove `SuccessfulQueryAnnotatedResult` case class when a better alternative to PR#257 has been found
-case class SuccessfulQueryAnnotatedResult(queryId: UUID, result: Array[Row], schema: StructType, colNames: Seq[String]
-                                         ) extends SQLResult {
-  override val resultSet = result
-
-  def hasError = false
-
-}
-
 case class ErrorResult(queryId: UUID, message: String, cause: Option[Throwable] = None) extends SQLResult {
   override lazy val resultSet = cause.fold(throw new RuntimeException(message)) {
     throwable => throw new RuntimeException(message,throwable)

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/test/SharedXDContextTypesTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/test/SharedXDContextTypesTest.scala
@@ -69,8 +69,8 @@ trait SharedXDContextTypesTest extends SharedXDContextWithDataTest {
     if(typesSet.map(_.colname) contains "structofstruct")
       it should "provide flattened column names through the `annotatedCollect` method" in {
         val dataFrame = sql("SELECT structofstruct.struct1.structField1 FROM typesCheckTable")
-        val (_, colNames) = dataFrame.asInstanceOf[XDDataFrame].annotatedCollect()
-        colNames.head shouldBe "structofstruct.struct1.structField1"
+        val rows = dataFrame.asInstanceOf[XDDataFrame].flattenedCollect()
+        rows.head.schema.head.name shouldBe "structofstruct.struct1.structField1"
       }
   }
 

--- a/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
@@ -18,7 +18,7 @@ package com.stratio.crossdata.server.actors
 import akka.actor.{Actor, Props}
 import akka.cluster.Cluster
 import com.stratio.crossdata.common.SQLCommand
-import com.stratio.crossdata.common.result.{SuccessfulQueryAnnotatedResult, ErrorResult, SuccessfulQueryResult}
+import com.stratio.crossdata.common.result.{ErrorResult, SuccessfulQueryResult}
 import com.stratio.crossdata.server.config.ServerConfig
 import org.apache.log4j.Logger
 import org.apache.spark.sql.crossdata.{XDDataFrame, XDContext}
@@ -38,12 +38,8 @@ class ServerActor(cluster: Cluster, xdContext: XDContext) extends Actor with Ser
       logger.debug(s"Query received ${sqlCommand.queryId}: ${sqlCommand.query}. Actor ${self.path.toStringWithoutAddress}")
       try {
         val df = xdContext.sql(query)
-        val response = if(withColnames) {
-          //TODO: Remove response differentiation when a better solution than PR#257 has been found
-          val (rows, cols) = df.asInstanceOf[XDDataFrame].annotatedCollect()
-          SuccessfulQueryAnnotatedResult(sqlCommand.queryId, rows, df.schema, cols)
-        } else SuccessfulQueryResult(sqlCommand.queryId, df.collect(), df.schema)
-        sender ! response
+        val rows = if(withColnames) df.asInstanceOf[XDDataFrame].flattenedCollect() else df.collect()
+        sender ! SuccessfulQueryResult(sqlCommand.queryId, rows, df.schema)
       } catch {
         case e: Throwable => {
           logger.error(e.getMessage)


### PR DESCRIPTION
`annotatedCollect` has been changed to `flattenedCollect` which implies that `SuccessfulQueryAnnotatedResult` server answer disappears.

`annotatedCollect` result now always contains a fully flattened schema where
each column name is also fully qualified.