### PR TITLE
[CROSSDATA-236][CROSSDATA-237] Support persisted views in Spark

### DIFF
--- a/core/src/main/resources/core-reference.conf
+++ b/core/src/main/resources/core-reference.conf
@@ -19,6 +19,7 @@ crossdata-core.catalog.caseSensitive = true
 #crossdata-core.catalog.jdbc.url = "jdbc:mysql://127.0.0.1:3306/"
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
 #crossdata-core.catalog.jdbc.db.table = "crossdataTables"
+#crossdata-core.catalog.jdbc.db.view = "crossdataViews"
 #crossdata-core.catalog.jdbc.db.user = "root"
 #crossdata-core.catalog.jdbc.db.pass = ""
 
@@ -27,6 +28,7 @@ crossdata-core.catalog.caseSensitive = true
 #crossdata-core.catalog.jdbc.url = "jdbc:postgresql://127.0.0.1:5432/"
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
 #crossdata-core.catalog.jdbc.db.table = "crossdataTables"
+#crossdata-core.catalog.jdbc.db.view = "crossdataViews"
 #crossdata-core.catalog.jdbc.db.user = "postgres"
 #crossdata-core.catalog.jdbc.db.pass = "postgres"
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/DerbyCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/DerbyCatalog.scala
@@ -22,6 +22,7 @@ import java.sql.ResultSet
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.CatalystConf
 import org.apache.spark.sql.catalyst.SimpleCatalystConf
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.crossdata.CrossdataVersion
 import org.apache.spark.sql.crossdata._
 import org.apache.spark.sql.types.StructType
@@ -195,4 +196,9 @@ class DerbyCatalog(override val conf: CatalystConf = new SimpleCatalystConf(true
 
   }
 
+  override protected def lookupView(tableName: String, databaseName: Option[String]): Option[String] =
+    ???
+
+  override protected[crossdata] def persistViewMetadata(tableIdentifier: TableIdentifier, sqlText: String): Unit =
+    ???
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/JDBCCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/JDBCCatalog.scala
@@ -22,6 +22,7 @@ import java.sql.ResultSet
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.CatalystConf
 import org.apache.spark.sql.catalyst.SimpleCatalystConf
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.crossdata.XDContext
 import org.apache.spark.sql.crossdata.catalog
 import org.apache.spark.sql.crossdata.catalog.XDCatalog.CrossdataTable
@@ -198,6 +199,9 @@ class JDBCCatalog(override val conf: CatalystConf = new SimpleCatalystConf(true)
 
   override def dropAllPersistedTables(): Unit = 
     connection.createStatement.executeUpdate(s"TRUNCATE $db.$table")
-  
+
+  override protected def lookupView(tableName: String, databaseName: Option[String]): Option[String] = ???
+
+  override protected[crossdata] def persistViewMetadata(tableIdentifier: TableIdentifier, sqlText: String): Unit = ???
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/JDBCCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/JDBCCatalog.scala
@@ -74,6 +74,7 @@ class JDBCCatalog(override val conf: CatalystConf = new SimpleCatalystConf(true)
   private val db = config.getString(Database)
   private val tableWithTableMetadata = config.getString(TableWithTableMetadata)
   private val tableWithViewMetadata = config.getString(TableWithViewMetadata)
+
   lazy val connection: Connection = {
 
     val driver = config.getString(Driver)
@@ -154,50 +155,52 @@ class JDBCCatalog(override val conf: CatalystConf = new SimpleCatalystConf(true)
     getSequenceAux(resultSet, resultSet.next).map(tableId => (tableId, false)).toSeq
   }
 
-  override def persistTableMetadata(crossdataTable: CrossdataTable): Unit = {
+  override def persistTableMetadata(crossdataTable: CrossdataTable): Unit =
+    try {
 
-    val tableSchema = serializeSchema(crossdataTable.userSpecifiedSchema.getOrElse(new StructType()))
+      val tableSchema = serializeSchema(crossdataTable.userSpecifiedSchema.getOrElse(new StructType()))
+      val tableOptions = serializeOptions(crossdataTable.opts)
+      val partitionColumn = serializePartitionColumn(crossdataTable.partitionColumn)
 
-    val tableOptions = serializeOptions(crossdataTable.opts)
-    val partitionColumn = serializePartitionColumn(crossdataTable.partitionColumn)
+      connection.setAutoCommit(false)
 
-    connection.setAutoCommit(false)
+      // check if the database-table exist in the persisted catalog
+      val resultSet = selectMetadata(tableWithTableMetadata, TableIdentifier(crossdataTable.tableName, crossdataTable.dbName))
 
-    // check if the database-table exist in the persisted catalog
-    val resultSet = selectMetadata(tableWithTableMetadata, TableIdentifier(crossdataTable.tableName, crossdataTable.dbName))
-
-    if (!resultSet.isBeforeFirst) {
-      val prepped = connection.prepareStatement(
-       s"""|INSERT INTO $db.$tableWithTableMetadata (
-           | $DatabaseField, $TableNameField, $SchemaField, $DatasourceField, $PartitionColumnField, $OptionsField, $CrossdataVersionField
-           |) VALUES (?,?,?,?,?,?,?)
+      if (!resultSet.isBeforeFirst) {
+        val prepped = connection.prepareStatement(
+          s"""|INSERT INTO $db.$tableWithTableMetadata (
+              | $DatabaseField, $TableNameField, $SchemaField, $DatasourceField, $PartitionColumnField, $OptionsField, $CrossdataVersionField
+              |) VALUES (?,?,?,?,?,?,?)
        """.stripMargin)
-      prepped.setString(1, crossdataTable.dbName.getOrElse(""))
-      prepped.setString(2, crossdataTable.tableName)
-      prepped.setString(3, tableSchema)
-      prepped.setString(4, crossdataTable.datasource)
-      prepped.setString(5, partitionColumn)
-      prepped.setString(6, tableOptions)
-      prepped.setString(7, CrossdataVersion)
-      prepped.execute()
-    }
-    else {
-     val prepped = connection.prepareStatement(
-      s"""|UPDATE $db.$tableWithTableMetadata SET $SchemaField=?, $DatasourceField=?,$PartitionColumnField=?,$OptionsField=?,$CrossdataVersionField=?
-          |WHERE $DatabaseField='${crossdataTable.dbName.getOrElse("")}' AND $TableNameField='${crossdataTable.tableName}';
+        prepped.setString(1, crossdataTable.dbName.getOrElse(""))
+        prepped.setString(2, crossdataTable.tableName)
+        prepped.setString(3, tableSchema)
+        prepped.setString(4, crossdataTable.datasource)
+        prepped.setString(5, partitionColumn)
+        prepped.setString(6, tableOptions)
+        prepped.setString(7, CrossdataVersion)
+        prepped.execute()
+      } else {
+        val prepped =
+          connection.prepareStatement(
+            s"""|UPDATE $db.$tableWithTableMetadata
+                |SET $SchemaField=?, $DatasourceField=?,$PartitionColumnField=?,$OptionsField=?,$CrossdataVersionField=?
+                |WHERE $DatabaseField='${crossdataTable.dbName.getOrElse("")}' AND $TableNameField='${crossdataTable.tableName}';
        """.stripMargin.replaceAll("\n", " "))
 
-      prepped.setString(1, tableSchema)
-      prepped.setString(2, crossdataTable.datasource)
-      prepped.setString(3, partitionColumn)
-      prepped.setString(4, tableOptions)
-      prepped.setString(5, CrossdataVersion)
-      prepped.execute()
-    }
-    connection.commit()
-    connection.setAutoCommit(true)
+        prepped.setString(1, tableSchema)
+        prepped.setString(2, crossdataTable.datasource)
+        prepped.setString(3, partitionColumn)
+        prepped.setString(4, tableOptions)
+        prepped.setString(5, CrossdataVersion)
+        prepped.execute()
+      }
+      connection.commit()
 
-  }
+    } finally {
+      connection.setAutoCommit(true)
+    }
 
   override def dropPersistedTable(tableName: String, databaseName: Option[String]): Unit = {
     connection.createStatement.executeUpdate(s"DELETE FROM $db.$tableWithTableMetadata WHERE tableName='$tableName' AND db='${databaseName.getOrElse("")}'")

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/XDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/XDCatalog.scala
@@ -99,7 +99,7 @@ abstract class XDCatalog(val conf: CatalystConf = new SimpleCatalystConf(true),
 
           lookupView(table, database) match {
             case Some(sqlView) =>
-              val viewPlan: LogicalPlan = xdContext.sql(s"CREATE TEMPORARY VIEW $tableIdent AS $sqlView").logicalPlan
+              val viewPlan: LogicalPlan = xdContext.sql(sqlView).logicalPlan
               registerView(tableIdent, viewPlan)
               processAlias(tableIdent, viewPlan, alias)
             case None =>

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/XDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/XDCatalog.scala
@@ -17,13 +17,17 @@ package org.apache.spark.sql.crossdata.catalog
 
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.analysis.Catalog
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Subquery}
-import org.apache.spark.sql.catalyst.{CatalystConf, SimpleCatalystConf, TableIdentifier}
-import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
-import org.apache.spark.sql.execution.datasources.{LogicalRelation, ResolvedDataSource}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.Subquery
+import org.apache.spark.sql.catalyst.CatalystConf
+import org.apache.spark.sql.catalyst.SimpleCatalystConf
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.crossdata.CrossdataVersion
 import org.apache.spark.sql.crossdata.XDContext
 import org.apache.spark.sql.crossdata.catalog.XDCatalog.CrossdataTable
+import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.ResolvedDataSource
 import org.apache.spark.sql.types._
 import org.json4s.jackson.Serialization.write
 
@@ -80,17 +84,27 @@ abstract class XDCatalog(val conf: CatalystConf = new SimpleCatalystConf(true),
 
   override def lookupRelation(tableIdentifier: Seq[String], alias: Option[String]): LogicalPlan = {
     val tableIdent = processTableIdentifier(tableIdentifier)
+
     lookupRelationCache(tableIdent, alias).getOrElse {
       val (table, database) = tableIdToTuple(tableIdent)
       logInfo(s"XDCatalog: Looking up table ${tableIdent.mkString(".")}")
+
       lookupTable(table, database) match {
         case Some(crossdataTable) =>
           val table: LogicalPlan = createLogicalRelation(crossdataTable)
           registerTable(tableIdent, table)
           processAlias(tableIdent, table, alias)
-
         case None =>
-          sys.error(s"Table Not Found: ${tableIdent.mkString(".")}")
+          log.debug(s"Table Not Found: ${tableIdent.mkString(".")}")
+
+          lookupView(table, database) match {
+            case Some(sqlView) =>
+              val viewPlan: LogicalPlan = xdContext.sql(s"CREATE TEMPORARY VIEW $tableIdent AS $sqlView").logicalPlan
+              registerView(tableIdent, viewPlan)
+              processAlias(tableIdent, viewPlan, alias)
+            case None =>
+              sys.error(s"Table/View Not Found: ${tableIdent.mkString(".")}")
+          }
       }
     }
   }
@@ -154,7 +168,19 @@ abstract class XDCatalog(val conf: CatalystConf = new SimpleCatalystConf(true),
       val tableIdentifier = TableIdentifier(crossdataTable.tableName,crossdataTable.dbName).toSeq
       registerTable(tableIdentifier, table)
     }
+  }
 
+  final def persistView(tableIdentifier: TableIdentifier, plan: LogicalPlan, sqlText: String) = {
+    val tableIdent = tableIdentifier.toSeq
+
+    if (tableExists(tableIdent)){
+      logWarning(s"The view ${tableIdent mkString "."} already exists")
+      throw new UnsupportedOperationException(s"The view $tableIdentifier already exists")
+    } else {
+      logInfo(s"XDCatalog: Persisting view ${tableIdent mkString "."}")
+      persistViewMetadata(tableIdentifier: TableIdentifier, sqlText)
+      registerView(tableIdentifier.toSeq, plan)
+    }
   }
 
   final def dropTable(tableIdentifier: Seq[String]): Unit = {
@@ -170,7 +196,11 @@ abstract class XDCatalog(val conf: CatalystConf = new SimpleCatalystConf(true),
     dropAllPersistedTables()
   }
 
-  def registerView(tableIdentifier: Seq[String], plan: LogicalPlan) = registerTable(tableIdentifier, plan)
+
+  def registerView(tableIdentifier: Seq[String], plan: LogicalPlan) =
+    registerTable(tableIdentifier, plan)
+
+  protected def lookupView(tableName: String, databaseName: Option[String]): Option[String]
 
   protected def lookupTable(tableName: String, databaseName: Option[String]): Option[CrossdataTable]
 
@@ -179,6 +209,8 @@ abstract class XDCatalog(val conf: CatalystConf = new SimpleCatalystConf(true),
   // TODO protected catalog
 
   protected[crossdata] def persistTableMetadata(crossdataTable: CrossdataTable): Unit
+
+  protected[crossdata] def persistViewMetadata(tableIdentifier: TableIdentifier, sqlText: String): Unit
 
   /**
    * Drop table if exists.

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/ZookeeperCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/ZookeeperCatalog.scala
@@ -96,4 +96,8 @@ class ZookeeperCatalog(override val conf: CatalystConf = new SimpleCatalystConf(
 
   override def dropAllPersistedTables(): Unit = dao.getAll().foreach(tableModel => dao.delete(tableModel.id))
 
+  override protected def lookupView(tableName: String, databaseName: Option[String]): Option[String] = ???
+
+  override protected[crossdata] def persistViewMetadata(tableIdentifier: TableIdentifier, sqlText: String): Unit = ???
+
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParser.scala
@@ -42,14 +42,13 @@ class XDDdlParser(parseQuery: String => LogicalPlan) extends DDLParser(parseQuer
 
 
   protected lazy val createView: Parser[LogicalPlan] = {
-    // TODO: Support database.table.
+
     (CREATE ~> TEMPORARY.? <~ VIEW) ~ tableIdentifier ~ (AS ~> restInput) ^^ {
       case temp  ~ viewIdentifier ~ query =>
         if (temp.isDefined)
           CreateTempView(viewIdentifier, parseQuery(query))
         else
-          CreateView(viewIdentifier, query)
-
+          CreateView(viewIdentifier, parseQuery(query), query)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/execution/datasources/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/execution/datasources/ddl.scala
@@ -17,19 +17,21 @@ package org.apache.spark.sql.crossdata.execution.datasources
 
 import com.stratio.crossdata.connector.TableInventory
 import org.apache.spark.Logging
-
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.crossdata.catalog.XDCatalog
+import org.apache.spark.sql.crossdata.catalog.XDCatalog._
 import org.apache.spark.sql.execution.RunnableCommand
-import org.apache.spark.sql.execution.datasources.{ResolvedDataSource, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.ResolvedDataSource
 import org.apache.spark.sql.sources.RelationProvider
-
-import org.apache.spark.sql.types.{ArrayType, BooleanType, StringType, StructField, StructType}
-import org.apache.spark.sql.{AnalysisException, Row, SQLContext}
-
-import XDCatalog._
+import org.apache.spark.sql.types.ArrayType
+import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
 
 
 private [crossdata] case class ImportTablesUsingWithOptions(datasource: String, opts: Map[String, String])
@@ -113,6 +115,7 @@ private[crossdata] case class CreateView(viewIdentifier: TableIdentifier, queryP
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
     sqlContext.catalog.persistView(viewIdentifier, queryPlan, sql)
+    Seq.empty
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/execution/datasources/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/execution/datasources/ddl.scala
@@ -108,11 +108,11 @@ private[crossdata] case class CreateTempView(viewIdentifier: TableIdentifier, qu
 
 }
 
-private[crossdata] case class CreateView(viewIdentifier: TableIdentifier, query: String)
+private[crossdata] case class CreateView(viewIdentifier: TableIdentifier, queryPlan: LogicalPlan, sql: String)
   extends LogicalPlan with RunnableCommand {
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
-    throw new AnalysisException("Only temporary views are supported. Use CREATE TEMPORARY VIEW")
+    sqlContext.catalog.persistView(viewIdentifier, queryPlan, sql)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/GenericCatalogTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/GenericCatalogTests.scala
@@ -97,7 +97,6 @@ trait GenericCatalogTests extends SharedXDContextTest with CatalogConstants {
 
     xdContext.catalog.unregisterTable(tableIdentifier)
     val schemaDF = xdContext.sql(s"DESCRIBE $Database.$TableName")
-    schemaDF.show
     schemaDF.count() should be(3)
     val df = xdContext.sql(s"SELECT `$FieldWitStrangeChars` FROM $Database.$TableName")
     df shouldBe a[XDDataFrame]
@@ -112,7 +111,6 @@ trait GenericCatalogTests extends SharedXDContextTest with CatalogConstants {
     xdContext.catalog.persistTableMetadata(crossdataTable)
     xdContext.catalog.unregisterTable(tableIdentifier)
     val schemaDF = xdContext.sql(s"DESCRIBE $Database.$TableName")
-    schemaDF.show
     schemaDF.count() should be(1)
     val df = xdContext.sql(s"SELECT `$Field1Name` FROM $Database.$TableName")
     df shouldBe a[XDDataFrame]

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/GenericCatalogTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/GenericCatalogTests.scala
@@ -16,15 +16,15 @@
 
 package org.apache.spark.sql.crossdata.catalog
 
-import org.apache.spark.sql.crossdata.catalog.XDCatalog.CrossdataTable
 import org.apache.spark.sql.crossdata._
+import org.apache.spark.sql.crossdata.catalog.XDCatalog.CrossdataTable
 import org.apache.spark.sql.crossdata.test.SharedXDContextTest
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.types._
 
 trait GenericCatalogTests extends SharedXDContextTest with CatalogConstants {
 
-  val catalogName: String
+  def catalogName: String
 
   s"${catalogName}CatalogSpec" must "return a dataframe from a persist table without catalog using json datasource" in {
     val fields = Seq[StructField](Field1, Field2)

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/ViewsIT.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/ViewsIT.scala
@@ -39,7 +39,7 @@ class ViewsIT extends SharedXDContextTest {
     dataframe.collect() should have length 2
   }
 
-  "Create view" should "return an analysis exception" in {
+  "Create view" should "throw a not implemented error" in {
 
     val sqlContext = _xdContext
     import sqlContext.implicits._
@@ -48,8 +48,7 @@ class ViewsIT extends SharedXDContextTest {
 
     df.registerTempTable("person")
 
-    an [scala.NotImplementedError] should be thrownBy sql("CREATE VIEW vn AS SELECT * FROM person WHERE _1 < 3")
-
+    an [scala.NotImplementedError] should be thrownBy sql("CREATE VIEW persistedview AS SELECT * FROM person WHERE _1 < 3")
 
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/ViewsIT.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/ViewsIT.scala
@@ -41,6 +41,7 @@ class ViewsIT extends SharedXDContextTest {
     dataframe.collect() should have length 2
   }
 
+  // TODO When we can add views to Zookeeper catalog, Views' test should be moved to GenericCatalogTests in order to test the specific implementations.
   "Create view" should "persist a view in the catalog" in {
 
     val sqlContext = _xdContext
@@ -56,8 +57,6 @@ class ViewsIT extends SharedXDContextTest {
     dataframe shouldBe a[DataFrame]
     dataframe.collect() should have length 2
 
-
   }
-
 
 }

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/ViewsIT.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/ViewsIT.scala
@@ -15,7 +15,6 @@
  */
 package org.apache.spark.sql.crossdata.execution.datasources
 
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.crossdata.XDDataFrame
 import org.apache.spark.sql.crossdata.test.SharedXDContextTest
 import org.junit.runner.RunWith
@@ -49,7 +48,7 @@ class ViewsIT extends SharedXDContextTest {
 
     df.registerTempTable("person")
 
-    an [AnalysisException] should be thrownBy sql("CREATE VIEW vn AS SELECT * FROM person WHERE _1 < 3")
+    an [scala.NotImplementedError] should be thrownBy sql("CREATE VIEW vn AS SELECT * FROM person WHERE _1 < 3")
 
 
   }

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParserSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParserSpec.scala
@@ -17,7 +17,9 @@ package org.apache.spark.sql.crossdata.execution.datasources
 
 import com.stratio.crossdata.test.BaseXDTest
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.execution.datasources.{CreateTableUsing, DescribeCommand, RefreshTable}
+import org.apache.spark.sql.execution.datasources.CreateTableUsing
+import org.apache.spark.sql.execution.datasources.DescribeCommand
+import org.apache.spark.sql.execution.datasources.RefreshTable
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -107,7 +109,13 @@ class XDDdlParserSpec extends BaseXDTest {
   it should "successfully parse a CREATE VIEW into a CreateView RunnableCommand" in {
 
     val sentence = "CREATE VIEW vn AS SELECT * FROM tn"
-    parser.parse(sentence) shouldBe CreateView( TableIdentifier("vn"), " SELECT * FROM tn")
+    val logicalPlan = parser.parse(sentence)
+    logicalPlan shouldBe a [CreateView]
+    logicalPlan match {
+      case CreateView(tableIdent, lPlan, sqlView) =>
+        tableIdent shouldBe TableIdentifier("vn")
+        sqlView.trim shouldBe  "SELECT * FROM tn"
+    }
 
   }
 


### PR DESCRIPTION
- Core implementation of persisted views 
- Derby and JDBC implementation
- Catalog refactor

Zookeeper implementation is blocked by some improvements in common-utils.


