### PR TITLE
Autodown node

### DIFF
--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -51,6 +51,7 @@ crossdata-server.akka.cluster.retry-unsuccessful-join-after = 10s
 crossdata-server.akka.cluster.roles = [server]
 crossdata-server.akka.cluster.role = {}
 crossdata-server.akka.cluster.min-nr-of-members = 1
+crossdata-server.akka.cluster.auto-down-unreachable-after = 10s
 
 crossdata-server.akka.remote.startup-timeout = 10 s
 crossdata-server.akka.remote.shutdown-timeout = 10 s


### PR DESCRIPTION
This means that the cluster leader member will change the unreachable node status to down automatically after the configured time of unreachability.