### PR TITLE
[CROSSDATA-257][CD] Flattened arrays

### DIFF
--- a/cassandra/src/test/scala/com/stratio/crossdata/connector/cassandra/CassandraTypesIT.scala
+++ b/cassandra/src/test/scala/com/stratio/crossdata/connector/cassandra/CassandraTypesIT.scala
@@ -38,6 +38,7 @@ class CassandraTypesIT extends CassandraWithSharedContext with SharedXDContextTy
         s"CREATE TYPE $Catalog.STRUCT_DATE (field1 TIMESTAMP, field2 INT)"::
         s"CREATE TYPE $Catalog.STRUCT_STRUCT (field1 TIMESTAMP, field2 INT, struct1 frozen<STRUCT1>)"::
         s"CREATE TYPE $Catalog.STRUCT_DATE1 (structField1 TIMESTAMP, structField2 INT)"::
+        s"CREATE TYPE $Catalog.STRUCT_ARRAY_STRUCT (stringfield VARCHAR, arrayfield LIST<frozen<STRUCT>>)"::
         s"""
            |CREATE TABLE $Catalog.$TypesTable
            |(
@@ -67,7 +68,8 @@ class CassandraTypesIT extends CassandraWithSharedContext with SharedXDContextTy
            |  arraystruct LIST<frozen<STRUCT>>,
            |  arraystructwithdate LIST<frozen<STRUCT_DATE>>,
            |  structofstruct frozen<STRUCT_STRUCT>,
-           |  mapstruct MAP<VARCHAR, frozen<STRUCT_DATE1>>
+           |  mapstruct MAP<VARCHAR, frozen<STRUCT_DATE1>>,
+           |  arraystructarraystruct LIST<frozen<STRUCT_ARRAY_STRUCT>>
            |)
       """.stripMargin::Nil
 
@@ -75,18 +77,20 @@ class CassandraTypesIT extends CassandraWithSharedContext with SharedXDContextTy
 
     val dataQuery =
       s"""|
-        |INSERT INTO $Catalog.$TypesTable (
+          |INSERT INTO $Catalog.$TypesTable (
           |  id, int, bigint, long, string, boolean, double, float, decimalInt, decimalLong,
           |  decimalDouble, decimalFloat, date, timestamp, tinyint, smallint, binary,
           |  arrayint, arraystring, mapintint, mapstringint, mapstringstring, struct, arraystruct,
-          |  arraystructwithdate, structofstruct, mapstruct
-          |  )
+          |  arraystructwithdate, structofstruct, mapstruct, arraystructarraystruct
+          |)
           |VALUES (
           |	1,  2147483647, 9223372036854775807, 9223372036854775807, 'string', true,
           |	3.3, 3.3, 42, 42, 42.0, 42.0, '2015-11-30 10:00', '2015-11-30 10:00', 1, 1, textAsBlob('binary data'),
           |	[4, 42], ['hello', 'world'], { 0 : 1 }, {'b' : 2 }, {'a':'A', 'b':'B'}, {field1: 1, field2: 2}, [{field1: 1, field2: 2}],
           |	[{field1: 9223372036854775807, field2: 2}], {field1: 9223372036854775807, field2: 2, struct1: {structField1: 'string', structField2: 42}},
-          |	{'structid' : {structField1: 9223372036854775807, structField2: 42}}
+          |	{'structid' : {structField1: 9223372036854775807, structField2: 42}},
+          | [{stringfield: 'aa', arrayfield: [{field1: 1, field2: 2}, {field1: -1, field2: -2}]},
+          | {stringfield: 'bb', arrayfield: [{field1: 11, field2: 22}]}]
           |);
       """.stripMargin
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
@@ -180,7 +180,7 @@ class XDDataFrame private[sql](@transient override val sqlContext: SQLContext,
       cartesian(arrayColumnValues) map { case replacements: Seq[(Int, _)] =>
         val idx2newVal: Map[Int, Any] = replacements.toMap
         val values = elementsWithIndex map { case (prevVal, idx: Int) =>
-          idx2newVal.get(idx).getOrElse(prevVal)
+          idx2newVal.getOrElse(idx, prevVal)
         }
         new GenericRowWithSchema(values, newSchema)
       }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
@@ -26,8 +26,6 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation
 import XDDataFrame.findNativeQueryExecutor
 import org.apache.spark.sql.types.{ArrayType, StructField, StructType}
 
-import scala.collection.mutable.ArrayBuffer
-
 private[sql] object XDDataFrame {
 
   def apply(sqlContext: SQLContext, logicalPlan: LogicalPlan): DataFrame = {
@@ -107,7 +105,6 @@ class XDDataFrame private[sql](@transient override val sqlContext: SQLContext,
     }
   }
 
-  //TODO: Remove `annotatedCollect` wrapper method when a better alternative to PR#257 has been found
   def flattenedCollect(): Array[Row] = {
 
     def flattenProjectedColumns(exp: Expression, prev: List[String] = Nil): (List[String], Boolean) = exp match {

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/test/SharedXDContextTypesTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/test/SharedXDContextTypesTest.scala
@@ -90,7 +90,7 @@ trait SharedXDContextTypesTest extends SharedXDContextWithDataTest {
         case _ => false
       } shouldBe empty
 
-      // No struct columns should be dound in the result schema
+      // No struct columns should be found in the result schema
       res.head.schema filter {
         case StructField(_, _: StructType, _, _) => true
         case _ => false

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/test/SharedXDContextTypesTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/test/SharedXDContextTypesTest.scala
@@ -86,19 +86,16 @@ trait SharedXDContextTypesTest extends SharedXDContextWithDataTest {
 
       // No array columns should be found in the result schema
       res.head.schema filter {
-        case StructField(_, _: ArrayType, _, _) =>
-          true
-        case _ =>
-          false
+        case StructField(_, _: ArrayType, _, _) => true
+        case _ => false
       } shouldBe empty
 
       // No struct columns should be dound in the result schema
       res.head.schema filter {
-        case StructField(_, _: StructType, _, _) =>
-          true
-        case _ =>
-          false
-      }
+        case StructField(_, _: StructType, _, _) => true
+        case _ => false
+      } shouldBe empty
+
     }
 
   }

--- a/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoDataTypesCollection.scala
+++ b/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoDataTypesCollection.scala
@@ -69,7 +69,8 @@ trait MongoDataTypesCollection extends MongoWithSharedContext with SharedXDConte
             "arraystruct" -> arraystruct,
             "arraystructwithdate" -> arraystructwithdate,
             "structofstruct" -> structofstruct,
-            "mapstruct" -> mapstruct
+            "mapstruct" -> mapstruct,
+            "arraystructarraystruct" -> arraystructarraystruct
           )
         }
       }

--- a/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoWithSharedContext.scala
+++ b/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoWithSharedContext.scala
@@ -122,4 +122,17 @@ sealed trait MongoDefaultConstants {
   val struct = MongoDBObject("field1" -> 2 ,"field2" -> 3)
   val structofstruct = MongoDBObject("field1" -> date ,"field2" -> 3, "struct1" -> MongoDBObject("structField1"-> "structfield1", "structField2" -> 2))
 
+  // Complex compositions
+  val arraystructarraystruct = Seq(
+    MongoDBObject(
+      "stringfield" -> "aa",
+      "arrayfield" -> Seq(MongoDBObject("field1" -> 1, "field2" -> 2), MongoDBObject("field1" -> -1, "field2" -> -2))
+    ),
+    MongoDBObject(
+      "stringfield" -> "bb",
+      "arrayfield" -> Seq(MongoDBObject("field1" -> 11, "field2" -> 22)
+      )
+    )
+  )
+
 }


### PR DESCRIPTION
With this, `flattenedCollect` performs a bi-dimensional flattening thus removing structures as fields as well as arrays.  The former kind of flattening is the horizontal one whereas the latter is done vertically, that is: Each array element makes the row to be duplicated in a new row where the array is replaced by the element itself.