### PR TITLE
Fix arrayless flatdeletion

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
@@ -231,8 +231,8 @@ class XDDataFrame private[sql](@transient override val sqlContext: SQLContext,
         case (row: GenericRowWithSchema, currentSize) =>
           row.schema collectFirst {
             case StructField(_, _: ArrayType, _, _) =>
-              val vFlatStep = verticallyFlatRowArrays(row)(limit-currentSize.getOrElse(0))
-              iterativeFlatten(vFlatStep)(limit-vFlatStep.length+1)
+              val newLimit = limit-currentSize.getOrElse(0)
+              iterativeFlatten(verticallyFlatRowArrays(row)(newLimit))(newLimit)
           } getOrElse Seq(row)
         case (row: Row, _) => Seq(row)
       }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
@@ -231,7 +231,8 @@ class XDDataFrame private[sql](@transient override val sqlContext: SQLContext,
         case (row: GenericRowWithSchema, currentSize) =>
           row.schema collectFirst {
             case StructField(_, _: ArrayType, _, _) =>
-              iterativeFlatten(verticallyFlatRowArrays(row)(limit-currentSize.getOrElse(0)))(limit)
+              val vFlatStep = verticallyFlatRowArrays(row)(limit-currentSize.getOrElse(0))
+              iterativeFlatten(vFlatStep)(limit-vFlatStep.length+1)
           } getOrElse Seq(row)
         case (row: Row, _) => Seq(row)
       }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDDataFrame.scala
@@ -195,7 +195,7 @@ class XDDataFrame private[sql](@transient override val sqlContext: SQLContext,
 
       def cartesian[T](ls: Seq[Seq[T]]): Seq[Seq[T]] = (ls :\ Seq(Seq.empty[T])) {
         case (cur: Seq[T], prev) => for(x <- prev; y <- cur) yield y +: x
-      } filterNot(_.isEmpty)
+      }
 
       val newSchema = StructType(
         row.schema map {


### PR DESCRIPTION
Bug fixes:
- When a row lacked any array column it was getting deleted.
- Flattened limit wasn't being correctly applied.
- Because of the way the result schema was being calculated, `SHOW TABLES` queries failed when executed using the driver.