### PR TITLE
[WIP][CROSSDATA-343] Scala cross version builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Only listing significant user-visible, not internal code cleanups and minor bug fixes. 
 
+## 1.2.0 (upcoming)
+* Enabled Scala cross builds for Scala 2.10 and Scala 2.11.
+
 ## 1.1.0 (January 2016)
 * Flattener of subdocuments for relational interfaces 
 * Flattener of collections for relational interfaces

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -21,11 +21,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.stratio.crossdata</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>parent_2.10</artifactId>
         <version>1.2.0-SNAPSHOT</version>
     </parent>
     <groupId>com.stratio.crossdata.connector</groupId>
-    <artifactId>crossdata-cassandra</artifactId>
+    <artifactId>crossdata-cassandra_2.10</artifactId>
     <packaging>jar</packaging>
     <name>Cassandra Connector</name>
     <description>Crossdata Cassandra Connector</description>
@@ -38,7 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-core</artifactId>
+            <artifactId>crossdata-core_${scala.binary.version}</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-core</artifactId>
+            <artifactId>crossdata-core_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,12 +21,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>parent</artifactId>
+        <artifactId>parent_2.10</artifactId>
         <groupId>com.stratio.crossdata</groupId>
         <version>1.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>crossdata-common</artifactId>
+    <artifactId>crossdata-common_2.10</artifactId>
     <name>Common</name>
     <packaging>jar</packaging>
     <description>Common structures for communication between driver and server</description>
@@ -46,7 +46,7 @@
 
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-core</artifactId>
+            <artifactId>crossdata-core_${scala.binary.version}</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,11 +21,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.stratio.crossdata</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>parent_2.10</artifactId>
         <version>1.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>crossdata-core</artifactId>
+    <artifactId>crossdata-core_2.10</artifactId>
     <name>Core</name>
     <packaging>jar</packaging>
     <description>Some improvements for SparkSQL</description>
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>com.stratio.common</groupId>
-            <artifactId>common-utils</artifactId>
+            <artifactId>common-utils_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.stratio.crossdata</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>parent_2.10</artifactId>
         <version>1.2.0-SNAPSHOT</version>
     </parent>
 

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -21,12 +21,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>parent</artifactId>
+        <artifactId>parent_2.10</artifactId>
         <groupId>com.stratio.crossdata</groupId>
         <version>1.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>crossdata-driver</artifactId>
+    <artifactId>crossdata-driver_2.10</artifactId>
     <name>Driver</name>
     <description>Driver for Crossdata in order to communicate with the Crossdata Servers</description>
     <packaging>jar</packaging>
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-common</artifactId>
+            <artifactId>crossdata-common_${scala.binary.version}</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
@@ -67,13 +67,13 @@
         <!--TEST-->
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-server</artifactId>
+            <artifactId>crossdata-server_${scala.binary.version}</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-core</artifactId>
+            <artifactId>crossdata-core_${scala.binary.version}</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
@@ -95,8 +95,8 @@
                             <minimizeJar>true</minimizeJar>
                             <artifactSet>
                                 <includes>
-                                    <include>com.stratio.crossdata:crossdata-common</include>
-                                    <include>com.stratio.crossdata:crossdata-driver</include>
+                                    <include>com.stratio.crossdata:crossdata-common_${scala.binary.version}</include>
+                                    <include>com.stratio.crossdata:crossdata-driver_${scala.binary.version}</include>
                                     <include>org.apache.spark:spark-catalyst_${scala.binary.version}</include>
                                     <include>com.typesafe.akka:akka-actor_${scala.binary.version}</include>
                                     <include>com.typesafe.akka:akka-cluster_${scala.binary.version}</include>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -22,11 +22,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.stratio.crossdata</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>parent_2.10</artifactId>
         <version>1.2.0-SNAPSHOT</version>
     </parent>
     <groupId>com.stratio.crossdata.connector</groupId>
-    <artifactId>crossdata-elasticsearch</artifactId>
+    <artifactId>crossdata-elasticsearch_2.10</artifactId>
     <packaging>jar</packaging>
     <name>Elasticsearch Connector</name>
     <description>Crossdata Elasticsearch Connector</description>
@@ -41,7 +41,7 @@
 
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-core</artifactId>
+            <artifactId>crossdata-core_${scala.binary.version}</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-core</artifactId>
+            <artifactId>crossdata-core_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,11 +21,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.stratio</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>parent_2.10</artifactId>
         <version>0.5.0</version>
     </parent>
 
-    <artifactId>crossdata-examples</artifactId>
+    <artifactId>crossdata-examples_2.10</artifactId>
     <version>1.1.0-RC1</version>
     <packaging>jar</packaging>
     <name>Examples</name>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -21,11 +21,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.stratio.crossdata</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>parent_2.10</artifactId>
         <version>1.2.0-SNAPSHOT</version>
     </parent>
     <groupId>com.stratio.crossdata.connector</groupId>
-    <artifactId>crossdata-mongodb</artifactId>
+    <artifactId>crossdata-mongodb_2.10</artifactId>
     <packaging>jar</packaging>
     <name>MongoDB Connector</name>
     <description>Crossdata MongoDB connector</description>
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-core</artifactId>
+            <artifactId>crossdata-core_${scala.binary.version}</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-core</artifactId>
+            <artifactId>crossdata-core_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <groupId>com.stratio.crossdata</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>parent_2.10</artifactId>
     <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Stratio Crossdata Parent</name>
@@ -93,8 +93,6 @@
     </modules>
 
     <properties>
-        <scala.binary.version>2.10</scala.binary.version>
-        <scala.version>2.10.4</scala.version>
         <spark.version>1.5.2</spark.version>
         <scalatest.version>2.2.5</scalatest.version>
         <coverage.data.dir>${project.build.outputDirectory}</coverage.data.dir>
@@ -108,8 +106,15 @@
         <postgresql.version>9.2-1003-jdbc4</postgresql.version>
         <derby.version>10.12.1.1</derby.version>
         <jackson4s.version>3.2.11</jackson4s.version>
-        <common.utils.version>0.3.0</common.utils.version>
+        <common.utils.version>0.5.0</common.utils.version>
         <guava.version>18.0</guava.version>
+        <!-- Scala version and cross build properties -->
+        <scala.binary.version>2.10</scala.binary.version>
+        <scala.version>2.10.4</scala.version>
+        <scala_2.10.version>2.10.4</scala_2.10.version>
+        <scala_2.11.version>2.11.7</scala_2.11.version>
+        <default.scala.binary.version>2.10</default.scala.binary.version>
+        <default.scala.version>${scala_2.10.version}</default.scala.version>
     </properties>
 
     <dependencyManagement>
@@ -121,27 +126,27 @@
             </dependency>
             <dependency>
                 <groupId>com.stratio.crossdata</groupId>
-                <artifactId>crossdata-core</artifactId>
+                <artifactId>crossdata-core_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.stratio.crossdata.connector</groupId>
-                <artifactId>crossdata-cassandra</artifactId>
+                <artifactId>crossdata-cassandra_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.stratio.crossdata.connector</groupId>
-                <artifactId>crossdata-mongodb</artifactId>
+                <artifactId>crossdata-mongodb_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.stratio.crossdata.connector</groupId>
-                <artifactId>crossdata-elasticsearch</artifactId>
+                <artifactId>crossdata-elasticsearch_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.stratio.crossdata</groupId>
-                <artifactId>crossdata-common</artifactId>
+                <artifactId>crossdata-common_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -156,7 +161,7 @@
             </dependency>
             <dependency>
                 <groupId>com.stratio.common</groupId>
-                <artifactId>common-utils</artifactId>
+                <artifactId>common-utils_${scala.binary.version}</artifactId>
                 <version>${common.utils.version}</version>
             </dependency>
             <dependency>
@@ -209,8 +214,9 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>src/main/scala</sourceDirectory>
-        <testSourceDirectory>src/test/scala</testSourceDirectory>
+        <directory>${project.basedir}/target/${scala.binary.version}</directory>
+        <outputDirectory>${project.build.directory}/classes</outputDirectory>
+        <testOutputDirectory>${project.build.directory}/test-classes</testOutputDirectory>
         <plugins>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
@@ -236,6 +242,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <includes>
                         <include>**/*Spec.*</include>
                     </includes>
@@ -245,6 +252,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <reportsDirectory>${project.build.directory}/failsafe-reports</reportsDirectory>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <argLine>-Xmx1024m</argLine>
@@ -290,6 +298,16 @@
                     </excludes>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>com.stratio.mojo</groupId>
+                <artifactId>scala-cross-build-maven-plugin</artifactId>
+                <version>0.1.0-RC3</version>
+                <configuration>
+                    <defaultScalaBinaryVersion>${default.scala.binary.version}</defaultScalaBinaryVersion>
+                    <defaultScalaVersion>${default.scala.version}</defaultScalaVersion>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -313,26 +331,16 @@
 
         <profile>
             <id>scala-2.10</id>
-            <activation>
-                <property>
-                    <name>!scala-2.11</name>
-                </property>
-            </activation>
             <properties>
-                <scala.version>2.10.4</scala.version>
+                <scala.version>${scala_2.10.version}</scala.version>
                 <scala.binary.version>2.10</scala.binary.version>
             </properties>
         </profile>
 
         <profile>
             <id>scala-2.11</id>
-            <activation>
-                <property>
-                    <name>scala-2.11</name>
-                </property>
-            </activation>
             <properties>
-                <scala.version>2.11.7</scala.version>
+                <scala.version>${scala_2.11.version}</scala.version>
                 <scala.binary.version>2.11</scala.binary.version>
             </properties>
         </profile>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -21,12 +21,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>parent</artifactId>
+        <artifactId>parent_2.10</artifactId>
         <groupId>com.stratio.crossdata</groupId>
         <version>1.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>crossdata-server</artifactId>
+    <artifactId>crossdata-server_2.10</artifactId>
     <packaging>jar</packaging>
     <name>Server</name>
     <description>Crossdata Server</description>
@@ -35,24 +35,24 @@
     <dependencies>
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-common</artifactId>
+            <artifactId>crossdata-common_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-core</artifactId>
+            <artifactId>crossdata-core_${scala.binary.version}</artifactId>
         </dependency>
         <!--TODO remove connector dependencies if the server is executed on Spark cluster-->
         <dependency>
             <groupId>com.stratio.crossdata.connector</groupId>
-            <artifactId>crossdata-cassandra</artifactId>
+            <artifactId>crossdata-cassandra_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.stratio.crossdata.connector</groupId>
-            <artifactId>crossdata-mongodb</artifactId>
+            <artifactId>crossdata-mongodb_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.stratio.crossdata.connector</groupId>
-            <artifactId>crossdata-elasticsearch</artifactId>
+            <artifactId>crossdata-elasticsearch_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
@@ -61,17 +61,17 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-contrib_2.10</artifactId>
+            <artifactId>akka-contrib_${scala.binary.version}</artifactId>
             <version>${akka.version}</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-testkit_2.10</artifactId>
+            <artifactId>akka-testkit_${scala.binary.version}</artifactId>
             <version>${akka.version}</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-slf4j_2.10</artifactId>
+            <artifactId>akka-slf4j_${scala.binary.version}</artifactId>
             <version>${akka.version}</version>
         </dependency>
         <dependency>
@@ -86,7 +86,7 @@
         </dependency>
         <dependency>
             <groupId>com.stratio.crossdata</groupId>
-            <artifactId>crossdata-core</artifactId>
+            <artifactId>crossdata-core_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>

--- a/zeppelin/pom.xml
+++ b/zeppelin/pom.xml
@@ -25,7 +25,7 @@
     <version>0.6.0-incubating-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zeppelin-crossdata</artifactId>
+  <artifactId>zeppelin-crossdata_2.10</artifactId>
   <packaging>jar</packaging>
   <version>1.2.0-SNAPSHOT</version>
   <name>Zeppelin: Crossdata</name>
@@ -34,8 +34,14 @@
 
   <properties>
     <zeppelin.home>zeppelin_home</zeppelin.home>
-    <scala.binary.version>2.10</scala.binary.version>
     <crossdata.version>${project.version}</crossdata.version>
+    <!-- Scala version and cross build properties -->
+    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.10.4</scala.version>
+    <scala_2.10.version>2.10.4</scala_2.10.version>
+    <scala_2.11.version>2.11.7</scala_2.11.version>
+    <default.scala.binary.version>2.10</default.scala.binary.version>
+    <default.scala.version>${scala_2.10.version}</default.scala.version>
   </properties>
 
   <dependencies>
@@ -51,13 +57,13 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>zeppelin-interpreter</artifactId>
+      <artifactId>zeppelin-interpreter_${scala.binary.version}</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.stratio.crossdata</groupId>
-      <artifactId>crossdata-driver</artifactId>
+      <artifactId>crossdata-driver_${scala.binary.version}</artifactId>
       <version>${crossdata.version}</version>
     </dependency>
 
@@ -224,4 +230,18 @@
       </plugin>
     </plugins>
   </build>
+  <profile>
+    <id>scala-2.10</id>
+    <properties>
+      <scala.version>${scala_2.10.version}</scala.version>
+      <scala.binary.version>2.10</scala.binary.version>
+    </properties>
+  </profile>
+  <profile>
+    <id>scala-2.11</id>
+    <properties>
+      <scala.version>${scala_2.11.version}</scala.version>
+      <scala.binary.version>2.11</scala.binary.version>
+    </properties>
+  </profile>
 </project>


### PR DESCRIPTION
- Default Scala binary version is 2.10.
- Profiles scala-2.10 and scala-2.11 allow to switch binary version.
- Appended _2.10 to all artifactId by default.
- Added scala-cross-build-maven-plugin to help with Scala cross builds.