### PR TITLE
Fixed "NotSerializableException" when R uses Crossdata with its datasources.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDContext.scala
@@ -133,6 +133,7 @@ class XDContext private (@transient val sc: SparkContext,
     ServiceLoader.load(classOf[FunctionInventory], loader)
   }
 
+  @transient
   private lazy val functionInventoryServices: Seq[FunctionInventory] = {
     import scala.collection.JavaConversions._
     functionInventoryLoader.iterator().toSeq


### PR DESCRIPTION
`FunctionInventory` instances should be annotated as transient within `XDContext` since they are provided by connector instances which are not serializable