### PR TITLE
[CROSSDATA-348] Naive table cache synchronization

### DIFF
--- a/driver/src/main/scala/com/stratio/crossdata/driver/actor/ProxyActor.scala
+++ b/driver/src/main/scala/com/stratio/crossdata/driver/actor/ProxyActor.scala
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2015 Stratio (http://stratio.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+  * Copyright (C) 2015 Stratio (http://stratio.com)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package com.stratio.crossdata.driver.actor
 
 import akka.actor.{Actor, ActorRef, Props}
@@ -20,6 +20,8 @@ import akka.contrib.pattern.ClusterClient
 import com.stratio.crossdata.common.{AddJARCommand, SQLCommand, CommandEnvelope}
 import com.stratio.crossdata.driver.Driver
 import org.apache.log4j.Logger
+
+import scala.util.matching.Regex
 
 object ProxyActor {
   val ServerPath = "/user/crossdata-server"
@@ -35,16 +37,25 @@ class ProxyActor(clusterClientActor: ActorRef, driver: Driver) extends Actor {
 
   lazy val logger = Logger.getLogger(classOf[ProxyActor])
 
+  private val catalogOpExp: Regex = """^\s*CREATE\s+TEMPORARY\s+TABLE\s+.*$""".r
 
   override def receive: Receive = {
 
-    case secureSQLCommand @ CommandEnvelope(sqlCommand: SQLCommand, _) =>
-          logger.info(s"Sending query: ${sqlCommand.sql}")
-          clusterClientActor forward ClusterClient.Send(ProxyActor.ServerPath, secureSQLCommand, localAffinity = false)
+    /* TODO: This is a dirty trick to keep temporary tables synchronized at each XDContext
+        it should be fixed as soon as Spark version is updated to 1.6 since it'll enable
 
-    case secureSQLCommand @ CommandEnvelope(_:AddJARCommand, _) =>
-          logger.debug(s"Send Add Jar command to all servers")
-          clusterClientActor forward ClusterClient.SendToAll(ProxyActor.ServerPath, secureSQLCommand)
+     */
+    case secureSQLCommand @ CommandEnvelope(sqlCommand @ SQLCommand(sql @ catalogOpExp, _, _, _, _), _) =>
+      logger.info(s"Sending TEMPORARY TABLE creation query to all servers: $sql")
+      clusterClientActor forward ClusterClient.SendToAll(ProxyActor.ServerPath, secureSQLCommand)
+
+    case secureSQLCommand @ CommandEnvelope(sqlCommand: SQLCommand, _) =>
+      logger.info(s"Sending query: ${sqlCommand.sql}")
+      clusterClientActor forward ClusterClient.Send(ProxyActor.ServerPath, secureSQLCommand, localAffinity = false)
+
+    case secureSQLCommand @ CommandEnvelope(_: AddJARCommand, _) =>
+      logger.debug(s"Send Add Jar command to all servers")
+      clusterClientActor forward ClusterClient.SendToAll(ProxyActor.ServerPath, secureSQLCommand)
 
     case SQLCommand =>
       logger.warn("Command message not securitized. Message won't be sent to the Crossdata cluster")

--- a/driver/src/main/scala/com/stratio/crossdata/driver/actor/ProxyActor.scala
+++ b/driver/src/main/scala/com/stratio/crossdata/driver/actor/ProxyActor.scala
@@ -1,18 +1,19 @@
 /**
-  * Copyright (C) 2015 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.stratio.crossdata.driver.actor
 
 import akka.actor.{Actor, ActorRef, Props}


### PR DESCRIPTION
Temporary tables creation queries get distributed to all servers so local catalog caches are synchronized

This approach is temporary (as the tables it addresses) and should be changed ASAP