### PR TITLE
Workarround to support create multiple connections in JDBC.

### DIFF
--- a/driver/src/main/scala/com/stratio/crossdata/driver/JavaDriver.scala
+++ b/driver/src/main/scala/com/stratio/crossdata/driver/JavaDriver.scala
@@ -49,7 +49,7 @@ class JavaDriver private(driverConf: DriverConf,
 
   private lazy val logger = LoggerFactory.getLogger(classOf[JavaDriver])
 
-  private val scalaDriver = Driver.getOrCreate(driverConf, auth)
+  private val scalaDriver = Driver.create(driverConf, auth)
 
   /**
    * Sync execution with defaults: timeout 10 sec, nr-retries 2


### PR DESCRIPTION
Hi old friends & ex-coworkers. 

I got a issue when use the JDBC Driver creating multiple connections, and then close some of they and use the open ones. 

I thinks that the problem is about the use of the Object variable `activeDriver`, that is an unique for all the Virtual Machine, hence, when I close a connection, the only one open driver is closed, thus all the other connections loose their connection to Crossdata. 

Just review this PR and apply the better solution to this problem. 

