### PR TITLE
[CROSSDATA-371] Restrict create view over a temporary table

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/XDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/XDCatalog.scala
@@ -55,10 +55,7 @@ abstract class XDCatalog(val conf: CatalystConf = new SimpleCatalystConf(true),
     }
   }
 
-  def tableExistsInCatalog(tableIdentifier: Seq[String]): Boolean = {
-    val (table, database) = tableIdToTuple(tableIdentifier)
-    lookupTable(table, database).fold(false)(crossdataTable => true)
-  }
+  def tableExistsInCatalog(tableIdentifier: Seq[String]): Boolean = (lookupTable _ tupled tableIdToTuple(tableIdentifier)).fold(false)(crossdataTable=>true)
 
   override def getTables(databaseName: Option[String]): Seq[(String, Boolean)] = {
     def processDBIdentifier(dbName: String): String = if (conf.caseSensitiveAnalysis) dbName else dbName.toLowerCase

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/XDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/XDCatalog.scala
@@ -15,8 +15,8 @@
  */
 package org.apache.spark.sql.crossdata.catalog
 
-import org.apache.spark.sql.catalyst.analysis.Catalog
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Subquery}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedRelation, Catalog}
+import org.apache.spark.sql.catalyst.plans.logical.{Project, LogicalPlan, Subquery}
 import org.apache.spark.sql.catalyst.{CatalystConf, SimpleCatalystConf, TableIdentifier}
 import org.apache.spark.sql.crossdata.catalog.XDCatalog.CrossdataTable
 import org.apache.spark.sql.crossdata.execution.datasources.StreamingRelation
@@ -53,6 +53,11 @@ abstract class XDCatalog(val conf: CatalystConf = new SimpleCatalystConf(true),
         true
       }
     }
+  }
+
+  def tableExistsInCatalog(tableIdentifier: Seq[String]): Boolean = {
+    val (table, database) = tableIdToTuple(tableIdentifier)
+    lookupTable(table, database).fold(false)(crossdataTable => true)
   }
 
   override def getTables(databaseName: Option[String]): Seq[(String, Boolean)] = {
@@ -177,9 +182,20 @@ abstract class XDCatalog(val conf: CatalystConf = new SimpleCatalystConf(true),
     }
   }
 
-  final def persistView(tableIdentifier: TableIdentifier, plan: LogicalPlan, sqlText: String) = {
-    val tableIdent = tableIdentifier.toSeq
 
+
+  final def persistView(tableIdentifier: TableIdentifier, plan: LogicalPlan, sqlText: String) = {
+    def checkPlan(plan:LogicalPlan) {
+      plan collect {
+        case rel: UnresolvedRelation =>
+          if (!tableExistsInCatalog(rel.tableIdentifier)) throw new RuntimeException("Views only can be created with a previously persisted table")
+        case project:Project =>
+          checkPlan(project.child)
+        case _=>throw new RuntimeException("Views only can be created with a previously persisted table")
+      }
+    }
+    val tableIdent = tableIdentifier.toSeq
+    checkPlan(plan)
     if (tableExists(tableIdent)){
       logWarning(s"The view ${tableIdent mkString "."} already exists")
       throw new UnsupportedOperationException(s"The view $tableIdentifier already exists")

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/GenericCatalogTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/GenericCatalogTests.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.crossdata.catalog
 
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.crossdata._
 import org.apache.spark.sql.crossdata.catalog.XDCatalog.CrossdataTable
 import org.apache.spark.sql.crossdata.test.SharedXDContextTest
@@ -53,7 +54,8 @@ trait GenericCatalogTests extends SharedXDContextTest with CatalogConstants {
   it should s"drop view" in {
 
     val viewIdentifier = TableIdentifier(ViewName, Option(Database))
-    xdContext.catalog.persistView(viewIdentifier, null,sqlView)
+    val plan=new UnresolvedRelation(Seq(Database,TableName))
+    xdContext.catalog.persistView(viewIdentifier, plan, sqlView)
 
     xdContext.catalog.dropView(viewIdentifier.toSeq)
     xdContext.catalog.tableExists(viewIdentifier.toSeq) shouldBe false


### PR DESCRIPTION
This PR restrict the creation of views over previously persisted tables only.