### PR TITLE
Use prolific execution context to run the spark-driver code

### DIFF
--- a/server/src/main/scala/com/stratio/crossdata/server/actors/JobActor.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/actors/JobActor.scala
@@ -118,7 +118,7 @@ class JobActor(
 
       logger.debug(s"Starting Job under ${context.parent.path}")
 
-      implicit val _: ExecutionContext = ExecutionContext.fromExecutor(new ProlificExecutor)
+      import context.dispatcher
 
       val runningTask = launchTask
       runningTask.future onComplete {
@@ -160,7 +160,9 @@ class JobActor(
   }
 
   private def launchTask: Cancellable[SQLReply] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
+
+    implicit val _: ExecutionContext = ExecutionContext.fromExecutor(new ProlificExecutor)
+
     Cancellable {
       val df = xdContext.sql(command.sql)
       val rows = if (command.flattenResults)


### PR DESCRIPTION
The prolific ExecutionContext wasn't being used at the right place so the problem it was aimed to fix (spark failures because the same thread was being used for different collect calls) was still there.