### PR TITLE
[CROSSDATA-367] [SERVER] Server config file is now loaded only once

### DIFF
--- a/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
@@ -30,7 +30,7 @@ import com.stratio.crossdata.common._
 import com.stratio.crossdata.server.actors.JobActor.Commands.{StartJob, CancelJob}
 import com.stratio.crossdata.common.{CommandEnvelope, SQLCommand}
 import com.stratio.crossdata.server.actors.JobActor.Events.{JobCompleted, JobFailed}
-import com.stratio.crossdata.server.config.ServerConfig
+import com.stratio.crossdata.server.config.{ServerActorConfig, ServerConfig}
 import org.apache.log4j.Logger
 import org.apache.spark.sql.crossdata.XDContext
 import org.apache.spark.sql.types.StructType
@@ -43,7 +43,8 @@ object ServerActor {
 
   val managementTopic: String = "jobsManagement"
 
-  def props(cluster: Cluster, xdContext: XDContext): Props = Props(new ServerActor(cluster, xdContext))
+  def props(cluster: Cluster, xdContext: XDContext, config: ServerActorConfig): Props =
+    Props(new ServerActor(cluster, xdContext, config))
 
   protected case class JobId(requester: ActorRef, queryId: UUID)
 
@@ -58,12 +59,12 @@ object ServerActor {
 
 }
 
-class ServerActor(cluster: Cluster, xdContext: XDContext) extends Actor with ServerConfig {
+class ServerActor(cluster: Cluster, xdContext: XDContext, config: ServerActorConfig) extends Actor {
 
   import ServerActor._
   import ServerActor.ManagementMessages._
 
-  override lazy val logger = Logger.getLogger(classOf[ServerActor])
+  lazy val logger = Logger.getLogger(classOf[ServerActor])
 
   lazy val mediator = DistributedPubSubExtension(context.system).mediator
 
@@ -150,7 +151,6 @@ class ServerActor(cluster: Cluster, xdContext: XDContext) extends Actor with Ser
     case other:CommandEnvelope =>
       other.cmd
 
-
   }
 
   // Manages events from the `JobActor` which runs the task
@@ -194,7 +194,7 @@ class ServerActor(cluster: Cluster, xdContext: XDContext) extends Actor with Ser
       logger.warn(s"Something is going wrong! Unknown message: $any")
   }
 
-  private def sentenceToDeath(victim: ActorRef): Unit = completedJobTTL match {
+  private def sentenceToDeath(victim: ActorRef): Unit = config.completedJobTTL match {
     case finite: FiniteDuration =>
       context.system.scheduler.scheduleOnce(finite, self, FinishJob(victim))(context.dispatcher)
     case _ => // Reprieve by infinite limit
@@ -206,7 +206,7 @@ class ServerActor(cluster: Cluster, xdContext: XDContext) extends Actor with Ser
   }
 
   //TODO: Use number of tries and timeout configuration parameters
-  override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy(retryNoAttempts, retryCountWindow) {
+  override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy(config.retryNoAttempts, config.retryCountWindow) {
     case _ => Restart //Crashed job gets restarted (or not, depending on `retryNoAttempts` and `retryCountWindow`)
   }
 

--- a/server/src/main/scala/com/stratio/crossdata/server/config/ServerActorConfig.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/config/ServerActorConfig.scala
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.crossdata.server.config
+
+import scala.concurrent.duration.Duration
+
+case class ServerActorConfig(completedJobTTL: Duration, retryNoAttempts: Int, retryCountWindow: Duration)


### PR DESCRIPTION
Instead of reading the server config file for every instance of the Server Actor, the file is read only once and a few parameters of them are passed to every instance of the Server Actor.