### PR TITLE
[CROSSDATA-412] Compilation-time warnings fixes

### DIFF
--- a/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoQueryProcessorSpec.scala
+++ b/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoQueryProcessorSpec.scala
@@ -83,9 +83,9 @@ class MongoQueryProcessorSpec extends BaseXDTest {
     filters.get(ColumnAge) shouldBe a [DBObject]
 
     val inListValues = filters.get(ColumnAge).asInstanceOf[DBObject].get(QueryOperators.IN)
-    inListValues shouldBe a [Array[Any]]
-    inListValues.asInstanceOf[Array[Object]] should have size 2
-    inListValues.asInstanceOf[Array[Object]] should contain allOf (ValueAge, ValueAge2)
+    inListValues shouldBe a [Seq[_]]
+    inListValues.asInstanceOf[Array[Any]] should have size 2
+    inListValues.asInstanceOf[Array[Any]] should contain allOf (ValueAge, ValueAge2)
 
   }
 

--- a/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoQueryProcessorSpec.scala
+++ b/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoQueryProcessorSpec.scala
@@ -83,7 +83,7 @@ class MongoQueryProcessorSpec extends BaseXDTest {
     filters.get(ColumnAge) shouldBe a [DBObject]
 
     val inListValues = filters.get(ColumnAge).asInstanceOf[DBObject].get(QueryOperators.IN)
-    inListValues shouldBe a [Array[Any]]
+    inListValues should matchPattern { case _: Array[_] => }
     inListValues.asInstanceOf[Array[Any]] should have size 2
     inListValues.asInstanceOf[Array[Any]] should contain allOf (ValueAge, ValueAge2)
 

--- a/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoQueryProcessorSpec.scala
+++ b/mongodb/src/test/scala/com/stratio/crossdata/connector/mongodb/MongoQueryProcessorSpec.scala
@@ -83,7 +83,7 @@ class MongoQueryProcessorSpec extends BaseXDTest {
     filters.get(ColumnAge) shouldBe a [DBObject]
 
     val inListValues = filters.get(ColumnAge).asInstanceOf[DBObject].get(QueryOperators.IN)
-    inListValues shouldBe a [Seq[_]]
+    inListValues shouldBe a [Array[Any]]
     inListValues.asInstanceOf[Array[Any]] should have size 2
     inListValues.asInstanceOf[Array[Any]] should contain allOf (ValueAge, ValueAge2)
 

--- a/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
@@ -148,8 +148,6 @@ class ServerActor(cluster: Cluster, xdContext: XDContext, config: ServerActorCon
         // If it can't run here it should be executed somewhere else
         mediator ! Publish(managementTopic, DelegateCommand(sc, self))
       }
-    case other:CommandEnvelope =>
-      other.cmd
 
   }
 

--- a/streaming/src/test/scala/com/stratio/crossdata/streaming/kafka/KafkaInputSpec.scala
+++ b/streaming/src/test/scala/com/stratio/crossdata/streaming/kafka/KafkaInputSpec.scala
@@ -60,12 +60,7 @@ class KafkaInputSpec extends BaseStreamingXDTest with CommonValues {
 
   "KafkaInput" should "return a exception topics" in {
     val input = new KafkaInput(kafkaOptionsModelEmptyTopics)
-    val topics = Try(input.getTopics) match {
-      case Failure(ex) => ex
-    }
-    val expected = true
-
-    topics.isInstanceOf[IllegalStateException] should be(expected)
+    an[IllegalStateException] should be thrownBy input.getTopics
   }
 
   "KafkaInput" should "return a correct storageLevel" in {


### PR DESCRIPTION
- Changed non-idiomatic exception expectation at test
- Removed type-erasured checks
- Remove wrong `Receive` function branch

Yet to be fixed those generated by scala:doc because it can't find spark-sql document jar.