### PR TITLE
[CROSSDATA-459] Solve dependency conflicts in deb/rpm

### DIFF
--- a/core/src/main/resources/core-reference.conf
+++ b/core/src/main/resources/core-reference.conf
@@ -90,7 +90,7 @@ crossdata-core.hdfs.hdfsPort = ${?crossdata_hdfs_port}
 //#The checkpoint directory will be checkpointDirectory/ephemeralTableName
 //crossdata-core.streaming.checkpointDirectory = "/var/sds/crossdata"
 //crossdata-core.streaming.sparkHome = "/opt/sds/spark"
-//crossdata-core.streaming.appJar = "/opt/sds/crossdata/lib/crossdata-streaming-${project.version}-jar-with-dependencies.jar"
+//crossdata-core.streaming.appJar = "/opt/sds/crossdata/appjar/crossdata-streaming_${scala.binary.version}-${project.version}-jar-with-dependencies.jar"
 //#crossdata-core.streaming.jars = []
 //
 //

--- a/core/src/test/resources/core-reference.conf
+++ b/core/src/test/resources/core-reference.conf
@@ -73,7 +73,7 @@ crossdata-core.streaming.outputFormat = "ROW"
 #The checkpoint directory will be checkpointDirectory/ephemeralTableName
 crossdata-core.streaming.checkpointDirectory = "/tmp/spark"
 crossdata-core.streaming.sparkHome = "/opt/sds/spark"
-crossdata-core.streaming.appJar = "/etc/sds/crossdata/lib/crossdata-streaming-${project.version}-jar-with-dependencies.jar"
+crossdata-core.streaming.appJar = "/opt/sds/crossdata/appjar/crossdata-streaming_${scala.binary.version}-${project.version}-jar-with-dependencies.jar"
 #crossdata-core.streaming.jars = []
 
 ####### SparkOptions ###########

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -54,14 +54,12 @@
                             <copyConfigurationDirectory>true</copyConfigurationDirectory>
                             <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
                             <filterConfigurationDirectory>true</filterConfigurationDirectory>
-                            <assembleDirectory>${project.build.directory}/crossdata-dist-${project.parent.version}
-                            </assembleDirectory>
+                            <assembleDirectory>${project.build.directory}/crossdata-dist-${project.parent.version}</assembleDirectory>
                             <extraJvmArguments>$CROSSDATA_JAVA_OPTS</extraJvmArguments>
                             <licenseHeaderFile>src/main/include/LICENSE</licenseHeaderFile>
                             <binFolder>bin</binFolder>
                             <repositoryName>lib</repositoryName>
-                            <unixScriptTemplate>${project.basedir}/src/main/templates/server-script.sh
-                            </unixScriptTemplate>
+                            <unixScriptTemplate>${project.basedir}/src/main/templates/server-script.sh</unixScriptTemplate>
                             <programs>
                                 <program>
                                     <mainClass>com.stratio.crossdata.server.CrossdataApplication</mainClass>
@@ -181,7 +179,7 @@
                                     <from>
                                         ${project.build.directory}/crossdata-dist-${project.parent.version}/lib/com/stratio/crossdata/crossdata-streaming_${scala.binary.version}/${project.parent.version}
                                     </from>
-                                    <to>/opt/sds/crossdata/lib</to>
+                                    <to>/opt/sds/crossdata/appjar</to>
                                 </copyDirectory>
                                 <copyDirectory>
                                     <from>../driver/target/${scala.binary.version}/crossdata-shell-${project.parent.version}/bin</from>

--- a/dist/src/main/resources/server/core-application.conf
+++ b/dist/src/main/resources/server/core-application.conf
@@ -78,7 +78,7 @@ crossdata-core.catalog.caseSensitive = true
 //#The checkpoint directory will be checkpointDirectory/ephemeralTableName
 //crossdata-core.streaming.checkpointDirectory = "/var/sds/crossdata"
 //crossdata-core.streaming.sparkHome = "/opt/sds/spark"
-//crossdata-core.streaming.appJar = "/opt/sds/crossdata/lib/crossdata-streaming_${scala.binary.version}-${project.version}-jar-with-dependencies.jar"
+//crossdata-core.streaming.appJar = "/opt/sds/crossdata/appjar/crossdata-streaming_${scala.binary.version}-${project.version}-jar-with-dependencies.jar"
 //#crossdata-core.streaming.jars = []
 //
 //


### PR DESCRIPTION
Streaming-fat-jar should not be a dependency but an application-jar for spark. Thus, it has been removed from /opt/sds/crossdata/lib.