### PR TITLE
[CROSSDATA-465] Now it is possible to insert empty arrays and maps

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParser.scala
@@ -98,9 +98,9 @@ class XDDdlParser(parseQuery: String => LogicalPlan, xDContext: XDContext) exten
 
   protected lazy val tableValues: Parser[Seq[Any]] = "(" ~> repsep(mapValues | arrayValues | token, ",") <~ ")"
 
-  protected lazy val arrayValues: Parser[Any] = {
-    "[" ~> repsep(mapValues | token, ",") <~ "]"
-  }
+  protected lazy val arrayValues: Parser[Any] =
+    ("[" ~> repsep(mapValues | token, ",") <~ "]") | ("[" ~> success(List()) <~ "]")
+
 
   protected lazy val tokenMap: Parser[(Any,Any)] = {
     (token <~ "-" <~ ">") ~ (arrayValues | token) ^^ {
@@ -108,11 +108,10 @@ class XDDdlParser(parseQuery: String => LogicalPlan, xDContext: XDContext) exten
     }
   }
 
-  protected lazy val mapValues: Parser[Any] = {
+  protected lazy val mapValues: Parser[Map[Any, Any]] =
     "(" ~> repsep(tokenMap, ",") <~ ")" ^^ {
       case pairs => Map(pairs:_*)
-    }
-  }
+    } | "(" ~> success(Map.empty[Any, Any]) <~ ")"
 
 
   def token: Parser[String] = {

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParserSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParserSpec.scala
@@ -204,6 +204,14 @@ class XDDdlParserSpec extends BaseXDTest with MockitoSugar{
 
   }
 
+  it should "successfully parse a INSERT TABLE using empty maps and arrays provided in VALUES" in {
+
+    val sentence = """INSERT INTO tableId VALUES ([], ())"""
+    parser.parse(sentence) shouldBe
+      InsertIntoTable( TableIdentifier("tableId"), List(List(List(), Map())))
+
+  }
+
   it should "successfully parse a CREATE VIEW into a CreateView RunnableCommand" in {
 
     val sentence = "CREATE VIEW vn AS SELECT * FROM tn"


### PR DESCRIPTION
## Description

Before this PR, inserting empty arrays or map syntax was rather counter intuitive. Now, it is as easy as passing `[]` and `()` values for empty arrays and maps respectively. 

### Testing
- Unit tests has been added to check whether this change has been properly applied. 


