### PR TITLE
[CROSSDATA-512] [ELASTICSEARCH] Upgrade to 2.3

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -18,7 +18,7 @@ ITSERVICES:
         - SPARK_MODE=slave
         - SPARK_MASTER_HOST=%%SPARK#0
   - ELASTICSEARCH:
-      image: itzg/elasticsearch:latest
+      image: itzg/elasticsearch:2.x
       sleep: 5
       env:
         - CLUSTER=%%JUID

--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -18,10 +18,10 @@ ITSERVICES:
         - SPARK_MODE=slave
         - SPARK_MASTER_HOST=%%SPARK#0
   - ELASTICSEARCH:
-      image: elasticsearch:2.3
+      image: itzg/elasticsearch:latest
       sleep: 5
       env:
-        - es.node.name=%%JUID
+        - CLUSTER=%%JUID
   - CASSANDRA:
       image: stratio/cassandra-lucene-index:2.2.5.3
       sleep: 10

--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -18,10 +18,10 @@ ITSERVICES:
         - SPARK_MODE=slave
         - SPARK_MASTER_HOST=%%SPARK#0
   - ELASTICSEARCH:
-      image: stratio/elasticsearch:1.7.1
+      image: elasticsearch:2.3
       sleep: 5
       env:
-        - CLUSTER_NAME=%%JUID
+        - es.node.name=%%JUID
   - CASSANDRA:
       image: stratio/cassandra-lucene-index:2.2.5.3
       sleep: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Only listing significant user-visible, not internal code cleanups and minor bug fixes. 
 
+## 1.4.0 (Upcoming)
+* Upgrade to Elasticsearch 2.3
+
 ## 1.3.0 (June 2016)
 * Upgrade to Spark 1.6.1
 * Support for INSERT INTO

--- a/cleanDerbyDBs.sh
+++ b/cleanDerbyDBs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 exec 2>/dev/null
-find -type f -name derby.log -exec rm {} \;
-find -type d -name sampledb -exec rm -r {} \;
+find . -type f -name derby.log -exec rm {} \;
+find . -type d -name sampledb -exec rm -r {} \;

--- a/common/src/main/scala/com/stratio/crossdata/common/result/results.scala
+++ b/common/src/main/scala/com/stratio/crossdata/common/result/results.scala
@@ -25,6 +25,8 @@ trait Result {
 }
 
 trait SQLResult extends Result {
+
+  // TODO: Avoid to expose methods that some of their implementation throw an exception
   def resultSet: Array[Row]
 
   def schema: StructType

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <elastic.datasource.version>2.3.2</elastic.datasource.version>
-        <elastic4s.version>1.7.5</elastic4s.version>
+        <elastic4s.version>2.3.0</elastic4s.version>
     </properties>
     <dependencies>
 

--- a/elasticsearch/src/main/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchRowConverter.scala
+++ b/elasticsearch/src/main/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchRowConverter.scala
@@ -33,9 +33,9 @@ import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.sql.types.BooleanType
 import org.apache.spark.sql.types.DateType
 import org.apache.spark.sql.types.Decimal
-import org.elasticsearch.common.joda.time.DateTime
 import org.elasticsearch.search.SearchHit
 import org.elasticsearch.search.SearchHitField
+import org.joda.time.DateTime
 
 object ElasticSearchRowConverter {
 

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchConnectionUtilsIT.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchConnectionUtilsIT.scala
@@ -31,10 +31,12 @@ class ElasticSearchConnectionUtilsIT extends ElasticWithSharedContext with Elast
     )
 
     //Experimentation
-    val client = ElasticSearchConnectionUtils.buildClient(options)
+    ElasticSearchConnectionUtils.withClientDo(options){ client =>
 
-    //Expectations
-    client should not be (null)
+      //Expectations
+      client should not be (null)
+    }
+
   }
 
 
@@ -69,18 +71,18 @@ class ElasticSearchConnectionUtilsIT extends ElasticWithSharedContext with Elast
       "es.cluster" -> s"$ElasticClusterName"
     )
 
-    val client = ElasticSearchConnectionUtils.buildClient(options)
-    createIndex(client,"index_test",  typeMapping())
-    try {
-      //Experimentation
-      val types = ElasticSearchConnectionUtils.listTypes(options)
+    ElasticSearchConnectionUtils.withClientDo(options){ client =>
+      createIndex(client,"index_test",  typeMapping())
+      try {
+        //Experimentation
+        val types = ElasticSearchConnectionUtils.listTypes(options)
 
-      //Expectations
-      types should not be (null)
-      types.size should be > 1
-
-    }finally {
-      cleanTestData(client, "index_test")
+        //Expectations
+        types should not be (null)
+        types.size should be > 1
+      } finally {
+        cleanTestData(client, "index_test")
+      }
     }
   }
 
@@ -96,20 +98,20 @@ class ElasticSearchConnectionUtilsIT extends ElasticWithSharedContext with Elast
       "es.index" -> "empty_index"
     )
 
-    val client = ElasticSearchConnectionUtils.buildClient(options)
-    createIndex(client,"empty_index",  null)
+    ElasticSearchConnectionUtils.withClientDo(options){ client =>
+      createIndex(client,"empty_index",  null)
+      try {
+        //Experimentation
+        val types = ElasticSearchConnectionUtils.listTypes(options)
 
-    try {
-      //Experimentation
-      val types = ElasticSearchConnectionUtils.listTypes(options)
-
-      //Expectations
-      types should not be null
-      types.size should be (0)
-
-    }finally {
-      cleanTestData(client, "empty_index")
+        //Expectations
+        types should not be null
+        types.size should be (0)
+      } finally {
+        cleanTestData(client, "empty_index")
+      }
     }
+
   }
 
 }

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchCreateExternalTableIT.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchCreateExternalTableIT.scala
@@ -25,10 +25,10 @@ class ElasticSearchCreateExternalTableIT extends ElasticWithSharedContext {
     assumeEnvironmentIsUpAndRunning
 
     val createTableQueryString =
-      s"""|CREATE EXTERNAL TABLE $Index.newtable (id Integer, name String)
+      s"""|CREATE EXTERNAL TABLE $Index.newtable (id Integer, title String)
           |USING $SourceProvider
           |OPTIONS (
-          |es.resource '$Index/$Type',
+          |es.resource '$Index/newtable',
           |es.nodes '$ElasticHost',
           |es.port '$ElasticRestPort',
           |es.nativePort '$ElasticNativePort',
@@ -41,7 +41,7 @@ class ElasticSearchCreateExternalTableIT extends ElasticWithSharedContext {
     //Expectations
     val table = xdContext.table(s"$Index.newtable")
     table should not be null
-    table.schema.fieldNames should contain ("name")
+    table.schema.fieldNames should contain ("title")
 
     client.get.admin.indices.prepareTypesExists(Index).setTypes(Type).get.isExists shouldBe true
   }
@@ -49,7 +49,7 @@ class ElasticSearchCreateExternalTableIT extends ElasticWithSharedContext {
   it should "create an external table without es.resource" in {
     assumeEnvironmentIsUpAndRunning
     val createTableQUeryString =
-      s"""|CREATE EXTERNAL TABLE $Index.newtable2 (id Integer, name String)
+      s"""|CREATE EXTERNAL TABLE $Index.newtable2 (id Integer, city String)
           |USING $SourceProvider
           |OPTIONS (
           |es.nodes '$ElasticHost',
@@ -64,7 +64,7 @@ class ElasticSearchCreateExternalTableIT extends ElasticWithSharedContext {
     //Expectations
     val table = xdContext.table(s"$Index.newtable2")
     table should not be null
-    table.schema.fieldNames should contain ("name")
+    table.schema.fieldNames should contain ("city")
 
     client.get.admin.indices.prepareTypesExists(Index).setTypes("newtable2").get.isExists shouldBe true
 

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchImportTablesIT.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchImportTablesIT.scala
@@ -76,88 +76,89 @@ class ElasticSearchImportTablesIT extends ElasticWithSharedContext {
     assumeEnvironmentIsUpAndRunning
     xdContext.dropAllTables()
 
-    val client = ElasticSearchConnectionUtils.buildClient(connectionOptions)
+    ElasticSearchConnectionUtils.withClientDo(connectionOptions){ client =>
+      client.execute { index into Index -> "NewMapping" fields {
+        "name" -> "luis"
+      }}
 
-    client.execute { index into Index -> "NewMapping" fields {
-      "name" -> "luis"
-    }}
-
-    val importQuery =
-      s"""
-         |IMPORT TABLES
-         |USING $SourceProvider
-          |OPTIONS (
-          |es.nodes '$ElasticHost',
-          |es.port '$ElasticRestPort',
-          |es.nativePort '$ElasticNativePort',
-          |es.cluster '$ElasticClusterName',
-          |es.resource '$Index/$Type'
-          |)
+      val importQuery =
+        s"""
+           |IMPORT TABLES
+           |USING $SourceProvider
+           |OPTIONS (
+           |es.nodes '$ElasticHost',
+           |es.port '$ElasticRestPort',
+           |es.nativePort '$ElasticNativePort',
+           |es.cluster '$ElasticClusterName',
+           |es.resource '$Index/$Type'
+           |)
       """.stripMargin
 
-    //Experimentation
-    sql(importQuery)
+      //Experimentation
+      sql(importQuery)
 
-    //Expectations
-    xdContext.tableNames() should contain (s"$Index.$Type")
-    xdContext.tableNames() should not contain s"$Index.NewMapping"
+      //Expectations
+      xdContext.tableNames() should contain (s"$Index.$Type")
+      xdContext.tableNames() should not contain s"$Index.NewMapping"
+    }
   }
 
   it should "fail when infer schema with bad es.resource" in {
     assumeEnvironmentIsUpAndRunning
     xdContext.dropAllTables()
 
-    val client = ElasticSearchConnectionUtils.buildClient(connectionOptions)
+    ElasticSearchConnectionUtils.withClientDo(connectionOptions){ client =>
+      client.execute { index into Index -> "NewMapping" fields {
+        "name" -> "luis"
+      }}
 
-    client.execute { index into Index -> "NewMapping" fields {
-      "name" -> "luis"
-    }}
-
-    val importQuery =
-      s"""
-         |IMPORT TABLES
-         |USING $SourceProvider
-          |OPTIONS (
-          |es.nodes '$ElasticHost',
-          |es.port '$ElasticRestPort',
-          |es.nativePort '$ElasticNativePort',
-          |es.cluster '$ElasticClusterName',
-          |es.resource '$Type'
-                                                                                                                                                                |)
+      val importQuery =
+        s"""
+           |IMPORT TABLES
+           |USING $SourceProvider
+           |OPTIONS (
+           |es.nodes '$ElasticHost',
+           |es.port '$ElasticRestPort',
+           |es.nativePort '$ElasticNativePort',
+           |es.cluster '$ElasticClusterName',
+           |es.resource '$Type'
+           |)
       """.stripMargin
 
-    //Experimentation
-    an [IllegalArgumentException] should be thrownBy sql(importQuery)
+      //Experimentation
+      an [IllegalArgumentException] should be thrownBy sql(importQuery)
+    }
   }
 
   it should "infer schema after import all tables from a Cluster" in {
     assumeEnvironmentIsUpAndRunning
     xdContext.dropAllTables()
 
-    val client = ElasticSearchConnectionUtils.buildClient(connectionOptions)
-    createIndex(client,"index_test", typeMapping())
-    try {
-      val importQuery =
-        s"""
-           |IMPORT TABLES
-           |USING $SourceProvider
-            |OPTIONS (
-            |es.nodes '$ElasticHost',
-            |es.port '$ElasticRestPort',
-            |es.nativePort '$ElasticNativePort',
-            |es.cluster '$ElasticClusterName'
-            |)
+    ElasticSearchConnectionUtils.withClientDo(connectionOptions){ client =>
+      createIndex(client,"index_test", typeMapping())
+      try {
+        val importQuery =
+          s"""
+             |IMPORT TABLES
+             |USING $SourceProvider
+             |OPTIONS (
+             |es.nodes '$ElasticHost',
+             |es.port '$ElasticRestPort',
+             |es.nativePort '$ElasticNativePort',
+             |es.cluster '$ElasticClusterName'
+             |)
       """.stripMargin
 
-      //Experimentation:
-      sql(importQuery)
+        //Experimentation:
+        sql(importQuery)
 
-      //Expectations
-      sql("SHOW TABLES").count should be > 1l
-      xdContext.tableNames().length should be > 1
+        //Expectations
+        sql("SHOW TABLES").count should be > 1l
+        xdContext.tableNames().length should be > 1
 
-    }finally {
-      cleanTestData(client, "index_test")
+      } finally {
+        cleanTestData(client, "index_test")
+      }
     }
   }
 
@@ -165,27 +166,27 @@ class ElasticSearchImportTablesIT extends ElasticWithSharedContext {
     assumeEnvironmentIsUpAndRunning
     xdContext.dropAllTables()
 
-    val client = ElasticSearchConnectionUtils.buildClient(connectionOptions)
+    ElasticSearchConnectionUtils.withClientDo(connectionOptions){ client =>
+      client.execute { index into Index -> "NewMapping" fields {
+        "name" -> "luis"
+      }}
 
-    client.execute { index into Index -> "NewMapping" fields {
-      "name" -> "luis"
-    }}
-
-    val importQuery =
-      s"""
-         |IMPORT TABLES
-         |USING $SourceProvider
-         |OPTIONS (
-         |es.nodes '$ElasticHost',
-         |es.port '$ElasticRestPort',
-         |es.nativePort '$ElasticNativePort',
-         |es.resource '$Index/$Type'
-         |)
+      val importQuery =
+        s"""
+           |IMPORT TABLES
+           |USING $SourceProvider
+           |OPTIONS (
+           |es.nodes '$ElasticHost',
+           |es.port '$ElasticRestPort',
+           |es.nativePort '$ElasticNativePort',
+           |es.resource '$Index/$Type'
+           |)
       """.stripMargin
 
-    //Experimentation
-    an [RuntimeException] should be thrownBy sql(importQuery)
+      //Experimentation
+      an [RuntimeException] should be thrownBy sql(importQuery)
 
+    }
   }
 
   lazy val connectionOptions: Map[String, String] = Map(

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchQueryProcessorSpec.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchQueryProcessorSpec.scala
@@ -15,7 +15,7 @@
  */
 package com.stratio.crossdata.connector.elasticsearch
 
-import com.sksamuel.elastic4s.{IndexesTypes, SearchDefinition}
+import com.sksamuel.elastic4s.{IndexAndTypes, IndexesAndTypes, SearchDefinition}
 import com.stratio.crossdata.test.BaseXDTest
 import org.apache.spark.sql.catalyst.expressions.{Attribute, PrettyAttribute}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -40,7 +40,7 @@ class ElasticSearchQueryProcessorSpec extends BaseXDTest with MockitoSugar {
     val requiredColums: Array[Attribute] = Array(new PrettyAttribute("title"))
     val filters: Array[SourceFilter] = Array()
 
-    val indexType = IndexesTypes("movies/movie")
+    val indexType = IndexAndTypes("movies/movie")
     val query = new SearchDefinition(indexType)
 
     //Experimentation
@@ -63,7 +63,7 @@ class ElasticSearchQueryProcessorSpec extends BaseXDTest with MockitoSugar {
     val requiredColums: Array[Attribute] = Array(new PrettyAttribute("title"))
     val filters: Array[SourceFilter] = Array(EqualTo("year", 1990))
 
-    val indexType = IndexesTypes("movies/movie")
+    val indexType = IndexAndTypes("movies/movie")
     val query = new SearchDefinition(indexType)
 
     //Experimentation
@@ -71,7 +71,7 @@ class ElasticSearchQueryProcessorSpec extends BaseXDTest with MockitoSugar {
 
     //Expectations
     result should not be null
-    result.toString().replace("\n", "").replace(" ", "") should be("{\"query\":{\"bool\":{}},\"post_filter\":{\"bool\":{\"must\":{\"term\":{\"year\":\"1990\"}}}},\"fields\":\"title\"}")
+    result.toString().replace("\n", "").replace(" ", "") should be("{\"query\":{\"bool\":{}},\"post_filter\":{\"bool\":{\"must\":{\"term\":{\"year\":1990}}}},\"fields\":\"title\"}")
   }
 
 
@@ -86,7 +86,7 @@ class ElasticSearchQueryProcessorSpec extends BaseXDTest with MockitoSugar {
     val requiredColums: Array[Attribute] = Array(new PrettyAttribute("title"))
     val filters: Array[SourceFilter] = Array(EqualTo("year", 1990), EqualTo("Name", "Lord"))
 
-    val indexType = IndexesTypes("movies/movie")
+    val indexType = IndexesAndTypes("movies/movie")
     val query = new SearchDefinition(indexType)
 
     //Experimentation
@@ -94,6 +94,6 @@ class ElasticSearchQueryProcessorSpec extends BaseXDTest with MockitoSugar {
 
     //Expectations
     result should not be null
-    result.toString().replace("\n", "").replace(" ", "") should be("{\"query\":{\"bool\":{}},\"post_filter\":{\"bool\":{\"must\":[{\"term\":{\"year\":\"1990\"}},{\"term\":{\"Name\":\"Lord\"}}]}},\"fields\":\"title\"}")
+    result.toString().replace("\n", "").replace(" ", "") should be("{\"query\":{\"bool\":{}},\"post_filter\":{\"bool\":{\"must\":[{\"term\":{\"year\":1990}},{\"term\":{\"Name\":\"Lord\"}}]}},\"fields\":\"title\"}")
   }
 }

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchTypesIT.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchTypesIT.scala
@@ -18,7 +18,7 @@ package com.stratio.crossdata.connector.elasticsearch
 import java.util.Date
 
 import org.apache.spark.sql.crossdata.ExecutionType.Native
-import org.elasticsearch.common.joda.time.DateTime
+import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticsearchConnectorIT.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticsearchConnectorIT.scala
@@ -16,7 +16,7 @@
 package com.stratio.crossdata.connector.elasticsearch
 
 import org.apache.spark.sql.crossdata.ExecutionType._
-import org.elasticsearch.common.joda.time.DateTime
+import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/examples/src/main/scala/com/stratio/crossdata/examples/driver/CassandraExample.scala
+++ b/examples/src/main/scala/com/stratio/crossdata/examples/driver/CassandraExample.scala
@@ -15,6 +15,7 @@
  */
 package com.stratio.crossdata.examples.driver
 
+import com.stratio.crossdata.common.result.{ErrorSQLResult, SuccessfulSQLResult}
 import com.stratio.crossdata.driver.Driver
 import com.stratio.crossdata.driver.config.DriverConf
 import com.stratio.crossdata.examples.cassandra._
@@ -54,7 +55,10 @@ object DriverExample extends App with DefaultConstants {
     for {
       xdDriver <- driver
     } {
-      xdDriver.importTables(SourceProvider, CassandraOptions).waitForResult()
+      xdDriver.importTables(SourceProvider, CassandraOptions).waitForResult() match {
+        case result: SuccessfulSQLResult => println("Successful importation")
+        case error: ErrorSQLResult => sys.error(error.message)
+      }
       xdDriver.listTables().foreach(println(_))
       xdDriver.show(s"SELECT * FROM $Catalog.$Table")
     }

--- a/streaming/src/test/scala/org/apache/spark/streaming/kafka/CrossdataStreamingHelperProjectIT.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/kafka/CrossdataStreamingHelperProjectIT.scala
@@ -109,7 +109,7 @@ class CrossdataStreamingHelperProjectIT extends BaseSparkStreamingXDTest with Co
     zookeeperStreamingCatalog.getEphemeralTable(TableNameProject) match {
       case Some(ephemeralTable) =>
         ssc = CrossdataStreamingHelper.createContext(ephemeralTable, sparkConf, zookeeperConf, catalogConf)
-        val valuesToSent = Array( """{"name": "a"}""", """{"name": "c"}""")
+        val valuesToSent = Array("""{"name": "a"}""", """{"name": "c"}""")
         kafkaTestUtils.createTopic(TopicTestProject)
         kafkaTestUtils.sendMessages(TopicTestProject, valuesToSent)
         val resultList = new mutable.MutableList[String]()


### PR DESCRIPTION
## Description
This PR allows to work with Elasticsearch 2.3
The dependency of the elastic4s has been upgraded from 1.7 to 2.3

### Testing
- [x] Unit, integration tests: UTs & ITs working

### Documentation
- [x] Changelog update
- [x] Documentation link: https://stratio.atlassian.net/wiki/display/CROSSDATA1x4/Sql+-+Elasticsearch
