### PR TITLE
Resource local caches invalidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ target/
 .DS_Store
 **/xdhistory.txt
 checkpoint/
-project/
 **.BACKUP.*.*
 **.BASE.*.*
 **.LOCAL.*.*

--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -37,7 +37,7 @@ ITSERVICES:
       env:
         - ZOOKEEPER_HOSTS=%%ZOOKEEPER:2181
   - CROSSDATA:
-      image: stratio/crossdata-scala${target.replaceAll('\\.', '')}:TMP-${target}-${vars.version}
+      image: stratio/crossdata
 
 
 

--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -36,6 +36,10 @@ ITSERVICES:
       image: stratio/kafka:0.8.2.1
       env:
         - ZOOKEEPER_HOSTS=%%ZOOKEEPER:2181
+  - CROSSDATA:
+      image: stratio/crossdata-scala${target.replaceAll('\\.', '')}:TMP-${target}-${vars.version}
+
+
 
 ITPARAMETERS: >
     -Dcassandra.hosts.0=%%CASSANDRA

--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -36,8 +36,6 @@ ITSERVICES:
       image: stratio/kafka:0.8.2.1
       env:
         - ZOOKEEPER_HOSTS=%%ZOOKEEPER:2181
-  - CROSSDATA:
-      image: stratio/crossdata
 
 
 

--- a/core/src/main/scala/com/stratio/crossdata/util/CacheInvalidator.scala
+++ b/core/src/main/scala/com/stratio/crossdata/util/CacheInvalidator.scala
@@ -1,0 +1,7 @@
+package com.stratio.crossdata.util
+
+trait CacheInvalidator {
+
+  def invalidateCache: Unit
+
+}

--- a/core/src/main/scala/com/stratio/crossdata/util/CacheInvalidator.scala
+++ b/core/src/main/scala/com/stratio/crossdata/util/CacheInvalidator.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.stratio.crossdata.util
 
 trait CacheInvalidator {

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDSessionProvider.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDSessionProvider.scala
@@ -38,6 +38,7 @@ abstract class XDSessionProvider(
   import XDSessionProvider._
 
 
+  //NOTE: DO NEVER KEEP THE RETURNED REFERENCE FOR SEVERAL USES!
   def session(sessionID: SessionID): Try[XDSession]
 
   def newSession(sessionID: SessionID): Try[XDSession]

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/temporary/XDTemporaryCatalogWithInvalidation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/temporary/XDTemporaryCatalogWithInvalidation.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.sql.crossdata.catalog.temporary
 
 import com.stratio.crossdata.util.CacheInvalidator

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/temporary/XDTemporaryCatalogWithInvalidation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/temporary/XDTemporaryCatalogWithInvalidation.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.crossdata.catalog.interfaces.XDTemporaryCatalog
   * @param invalidator Cache invalidation implementation
   */
 class XDTemporaryCatalogWithInvalidation(
-                                          underlying: XDTemporaryCatalog,
+                                          val underlying: XDTemporaryCatalog,
                                           invalidator: CacheInvalidator
                                         ) extends XDTemporaryCatalog {
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/temporary/XDTemporaryCatalogWithInvalidation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/temporary/XDTemporaryCatalogWithInvalidation.scala
@@ -1,0 +1,60 @@
+package org.apache.spark.sql.crossdata.catalog.temporary
+
+import com.stratio.crossdata.util.CacheInvalidator
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.catalyst.CatalystConf
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.crossdata.catalog.XDCatalog.{CrossdataTable, ViewIdentifier}
+import org.apache.spark.sql.crossdata.catalog.interfaces.XDTemporaryCatalog
+
+/**
+  * Decorator class providing cache invalidation for non-conservative operations
+  *
+  * @param underlying Catalog implementation
+  * @param invalidator Cache invalidation implementation
+  */
+class XDTemporaryCatalogWithInvalidation(
+                                          underlying: XDTemporaryCatalog,
+                                          invalidator: CacheInvalidator
+                                        ) extends XDTemporaryCatalog {
+
+  override def saveTable(
+                          tableIdentifier: ViewIdentifier,
+                          plan: LogicalPlan,
+                          crossdataTable: Option[CrossdataTable]): Unit = {
+    invalidator.invalidateCache
+    underlying.saveTable(tableIdentifier, plan, crossdataTable)
+  }
+
+  override def saveView(viewIdentifier: ViewIdentifier, plan: LogicalPlan, query: Option[String]): Unit = {
+    invalidator.invalidateCache
+    underlying.saveView(viewIdentifier, plan, query)
+  }
+
+  override def dropView(viewIdentifier: ViewIdentifier): Unit = {
+    invalidator.invalidateCache
+    underlying.dropView(viewIdentifier)
+  }
+
+  override def dropAllViews(): Unit = {
+    invalidator.invalidateCache
+    underlying.dropAllViews()
+  }
+
+  override def dropAllTables(): Unit = {
+    invalidator.invalidateCache
+    underlying.dropAllTables()
+  }
+
+  override def dropTable(tableIdentifier: ViewIdentifier): Unit = {
+    invalidator.invalidateCache
+    underlying.dropTable(tableIdentifier)
+  }
+
+  override def relation(tableIdent: ViewIdentifier)(implicit sqlContext: SQLContext): Option[LogicalPlan] =
+    underlying.relation(tableIdent)
+
+  override def catalystConf: CatalystConf = underlying.catalystConf
+  override def isAvailable: Boolean = underlying.isAvailable
+  override def allRelations(databaseName: Option[String]): Seq[ViewIdentifier] = underlying.allRelations(databaseName)
+}

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParser.scala
@@ -77,7 +77,7 @@ class XDDdlParser(parseQuery: String => LogicalPlan, xDContext: XDContext) exten
   protected lazy val importStart: Parser[LogicalPlan] =
     IMPORT ~> TABLES ~> (USING ~> className) ~ (OPTIONS ~> options).? ^^ {
       case provider ~ ops =>
-        ImportTablesUsingWithOptions(provider.asInstanceOf[String], ops.getOrElse(Map.empty))
+        ImportTablesUsingWithOptions(provider, ops.getOrElse(Map.empty))
     }
 
   protected lazy val dropTable: Parser[LogicalPlan] =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/project/build.scala
+++ b/project/build.scala
@@ -1,0 +1,2 @@
+import sbt._
+object MyBuild extends com.typesafe.sbt.pom.PomBuild

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-pom-reader" % "2.1.0-RC2")

--- a/server/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/HazelcastCacheInvalidator.scala
+++ b/server/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/HazelcastCacheInvalidator.scala
@@ -1,0 +1,29 @@
+package org.apache.spark.sql.crossdata.catalog.persistent
+
+import com.hazelcast.core.ITopic
+import com.stratio.crossdata.util.CacheInvalidator
+import org.apache.spark.sql.crossdata.XDSessionProvider.SessionID
+import org.apache.spark.sql.crossdata.catalog.persistent.HazelcastCacheInvalidator.{CacheInvalidationEvent, ResourceInvalidation}
+
+object HazelcastCacheInvalidator {
+
+
+  trait CacheInvalidationEvent extends Serializable
+
+  case class ResourceInvalidation(sessionId: SessionID) extends CacheInvalidationEvent
+  case object ResourceInvalidationForAllSessions extends  CacheInvalidationEvent
+
+}
+
+class HazelcastCacheInvalidator(
+                                 sessionID: SessionID,
+                                 topic: ITopic[CacheInvalidationEvent]
+                               ) extends CacheInvalidator {
+
+  private val invalidateSessionEvent = ResourceInvalidation(sessionID)
+
+  override def invalidateCache: Unit = {
+    topic.publish(invalidateSessionEvent)
+  }
+
+}

--- a/server/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/HazelcastCacheInvalidator.scala
+++ b/server/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/HazelcastCacheInvalidator.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.sql.crossdata.catalog.persistent
 
 import com.hazelcast.core.ITopic

--- a/server/src/main/scala/org/apache/spark/sql/crossdata/session/SessionResourceManager.scala
+++ b/server/src/main/scala/org/apache/spark/sql/crossdata/session/SessionResourceManager.scala
@@ -85,7 +85,7 @@ class HazelcastSessionCatalogManager(
 
   invalidationTopic
 
-  private val sessionIDToMapCatalog: mutable.Map[SessionID, XDTemporaryCatalog] = mutable.Map.empty
+  private val sessionIDToMapCatalog: mutable.Map[SessionID, XDTemporaryCatalogWithInvalidation] = mutable.Map.empty
   private val sessionIDToTableViewID: IMap[SessionID, (TableMapUUID, ViewMapUUID)] = hInstance.getMap(HazelcastCatalogMapId)
 
   private def catalogInvalidator(sessionID: SessionID): CacheInvalidator =
@@ -150,7 +150,7 @@ class HazelcastSessionCatalogManager(
     (hInstance.getMap[K, V](randomUUID.toString), randomUUID)
   }
 
-  private def addNewMapCatalog(sessionID: SessionID): XDTemporaryCatalog = {
+  private def addNewMapCatalog(sessionID: SessionID): XDTemporaryCatalogWithInvalidation = {
     val localCatalog = new XDTemporaryCatalogWithInvalidation(
       new HashmapCatalog(catalystConf),
       catalogInvalidator(sessionID)

--- a/server/src/main/scala/org/apache/spark/sql/crossdata/session/SessionResourceManager.scala
+++ b/server/src/main/scala/org/apache/spark/sql/crossdata/session/SessionResourceManager.scala
@@ -83,6 +83,8 @@ class HazelcastSessionCatalogManager(
 
   override protected val topicName: String = "session-rec-catalog"
 
+  invalidationTopic
+
   private val sessionIDToMapCatalog: mutable.Map[SessionID, XDTemporaryCatalog] = mutable.Map.empty
   private val sessionIDToTableViewID: IMap[SessionID, (TableMapUUID, ViewMapUUID)] = hInstance.getMap(HazelcastCatalogMapId)
 

--- a/server/src/test/scala/org/apache/spark/sql/crossdata/session/HazelcastSessionCatalogManagerSpec.scala
+++ b/server/src/test/scala/org/apache/spark/sql/crossdata/session/HazelcastSessionCatalogManagerSpec.scala
@@ -1,0 +1,86 @@
+package org.apache.spark.sql.crossdata.session
+
+import java.util.UUID
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.{ImplicitSender, TestKit}
+import com.hazelcast.config.{GroupConfig, XmlConfigBuilder}
+import com.hazelcast.core.{Hazelcast, HazelcastInstance}
+import org.apache.spark.sql.catalyst.EmptyConf
+import org.apache.spark.sql.crossdata.XDSessionProvider.SessionID
+import org.apache.spark.sql.crossdata.session.HazelcastSessionCatalogManagerSpec.{InvalidatedSession, ProbedHazelcastSessionCatalogManager}
+import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+
+object HazelcastSessionCatalogManagerSpec {
+
+  private class ProbedHazelcastSessionCatalogManager(hInstance: HazelcastInstance)(implicit monitorActor: ActorRef)
+    extends HazelcastSessionCatalogManager(hInstance, EmptyConf) {
+
+    override def invalidateLocalCaches(key: SessionID): Unit = {
+      super.invalidateLocalCaches(key)
+      monitorActor ! InvalidatedSession(key)
+    }
+
+    override def invalidateAllLocalCaches: Unit = {
+      super.invalidateAllLocalCaches
+      monitorActor ! InvalidatedAllSessions
+    }
+
+  }
+
+  case class InvalidatedSession(sessionID: SessionID)
+  case object InvalidatedAllSessions
+
+}
+
+class HazelcastSessionCatalogManagerSpec extends TestKit(ActorSystem("HZSessionCatalogTest"))
+  with WordSpecLike
+  with BeforeAndAfterAll
+  with ImplicitSender {
+
+  // Test description
+
+  "HazelcastSessionCatalogManager local cache" when {
+
+    val sessionID: SessionID = UUID.randomUUID
+
+    "a catalog change at other peer has been performed" should {
+
+      "be invalidated if the change consist on adding or removing new catalogs" in {
+
+        catalogManager.newResource(sessionID)
+        expectMsg(InvalidatedSession(sessionID))
+
+        catalogManager.deleteSessionResource(sessionID)
+        expectMsg(InvalidatedSession(sessionID))
+
+      }
+
+
+    }
+
+  }
+
+  // Test plumbing
+
+  private def createHazelcastInstance: HazelcastInstance = {
+    val xmlConfig = new XmlConfigBuilder().build()
+    xmlConfig.setGroupConfig(new GroupConfig("test"))
+    Hazelcast.newHazelcastInstance(xmlConfig)
+  }
+
+  var catalogManager: HazelcastSessionCatalogManager = _
+  var probedCatalogManager: HazelcastSessionCatalogManager = _
+
+  override protected def beforeAll(): Unit = {
+    val hInstanceA = createHazelcastInstance
+    val hInstanceB = createHazelcastInstance
+
+    catalogManager = new HazelcastSessionCatalogManager(hInstanceA, EmptyConf)
+    probedCatalogManager = new ProbedHazelcastSessionCatalogManager(hInstanceB)
+
+  }
+
+  override protected def afterAll(): Unit = Hazelcast shutdownAll
+
+}

--- a/server/src/test/scala/org/apache/spark/sql/crossdata/session/HazelcastSessionCatalogManagerSpec.scala
+++ b/server/src/test/scala/org/apache/spark/sql/crossdata/session/HazelcastSessionCatalogManagerSpec.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.sql.crossdata.session
 
 import java.util.UUID

--- a/server/src/test/scala/org/apache/spark/sql/crossdata/session/HazelcastSessionProviderSpec.scala
+++ b/server/src/test/scala/org/apache/spark/sql/crossdata/session/HazelcastSessionProviderSpec.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.crossdata.XDSession
 import org.apache.spark.sql.crossdata.catalog.CatalogChain
 import org.apache.spark.sql.crossdata.catalog.XDCatalog.CrossdataTable
 import org.apache.spark.sql.crossdata.catalog.interfaces.{XDPersistentCatalog, XDTemporaryCatalog}
-import org.apache.spark.sql.crossdata.catalog.temporary.{HashmapCatalog, HazelcastCatalog}
+import org.apache.spark.sql.crossdata.catalog.temporary.{HashmapCatalog, HazelcastCatalog, XDTemporaryCatalogWithInvalidation}
 import org.apache.spark.sql.crossdata.test.SharedXDContextTest
 import org.junit.runner.RunWith
 import org.scalatest.Entry
@@ -49,7 +49,8 @@ class HazelcastSessionProviderSpec extends SharedXDContextTest {
     val tempCatalogs = tempCatalogsFromSession(session)
 
     tempCatalogs should have length 2
-    tempCatalogs.head shouldBe a[HashmapCatalog]
+    tempCatalogs.head shouldBe a[XDTemporaryCatalogWithInvalidation]
+    tempCatalogs.head.asInstanceOf[XDTemporaryCatalogWithInvalidation].underlying shouldBe a[HashmapCatalog]
     tempCatalogs(1) shouldBe a[HazelcastCatalog]
 
     hazelcastSessionProvider.close()


### PR DESCRIPTION
## Description

This PR adds the building blocks for local per-session-resource cache invalidation within the cluster and uses them to implement a hazelcast-topic based invalidator for session in memory catalogs.

### Testing
- [x] Unit

