### PR TITLE
[CROSSDATA-544]Working ES preventing remove tables

### DIFF
--- a/elasticsearch/src/main/scala/com/stratio/crossdata/connector/elasticsearch/DefaultSource.scala
+++ b/elasticsearch/src/main/scala/com/stratio/crossdata/connector/elasticsearch/DefaultSource.scala
@@ -185,16 +185,21 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider
   override def dropExternalTable(context: SQLContext,
                                  options: Map[String, String]): Try[Unit] = {
 
-    val (index, typeName) = ElasticSearchConnectionUtils.extractIndexAndType(options).get
-    val indexType = IndexAndType(index, typeName)
+    if(ElasticSearchConnectionUtils.numberOfTypes(options) == 1) {
+      val (index, typeName) = ElasticSearchConnectionUtils.extractIndexAndType(options).get
+      val indexType = IndexAndType(index, typeName)
 
-    Try {
-      ElasticSearchConnectionUtils.withClientDo(options){ client =>
-        client.execute {
-          deleteIndex(index)
-        }.await
+      Try {
+        ElasticSearchConnectionUtils.withClientDo(options){ client =>
+          client.execute {
+            deleteIndex(index)
+          }.await
+        }
       }
+    } else {
+      sys.error("Cannot remove table from ElasticSearch if more than one table is persisted in the same index. Please remove it natively")
     }
+
   }
 
 }

--- a/elasticsearch/src/main/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchConnectionUtils.scala
+++ b/elasticsearch/src/main/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchConnectionUtils.scala
@@ -80,6 +80,15 @@ object ElasticSearchConnectionUtils {
 
   }
 
+  def numberOfTypes(options: Map[String, String]): Int = {
+    val adminClient = buildClient(options).admin.indices()
+
+    val indexType: Option[(String, String)] =  extractIndexAndType(options)
+    val index = indexType.map(_._1).orElse(options.get(ElasticIndex)) getOrElse sys.error("Index not found")
+
+    adminClient.prepareGetIndex().addIndices(index).get().mappings().get(index).size()
+  }
+
   private def listIndexTypes(adminClient: IndicesAdminClient, indexName: String, typeName: Option[String] = None): Seq[Table] = {
 
     val elasticBuilder = adminClient.prepareGetIndex().addIndices(indexName)


### PR DESCRIPTION
## Description
If just one type exist in the Index we are able to delete it by removing all the index, if not the user is notified by an exception.

### Testing
- [X] Unit, integration tests

### Documentation
- [ ] Changelog update
- [ ] Documentation link

