### PR TITLE
[CROSSDATA-552] Prefix catalogs and Zookeeper configurable paths

### DIFF
--- a/core/src/main/resources/core-reference.conf
+++ b/core/src/main/resources/core-reference.conf
@@ -24,25 +24,18 @@ crossdata-core.launcher.sparkHome=${?crossdata_core_launcher_spark_home}
 #crossdata-core.catalog.jdbc.driver = "org.mariadb.jdbc.Driver"
 #crossdata-core.catalog.jdbc.url = "jdbc:mysql://127.0.0.1:3306/"
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
-#crossdata-core.catalog.jdbc.db.table = "crossdataTables"
-#crossdata-core.catalog.jdbc.db.view = "crossdataViews"
-#crossdata-core.catalog.jdbc.db.index = "crossdataIndexes"
-#crossdata-core.catalog.jdbc.db.app = "crossdataJars"
 #crossdata-core.catalog.jdbc.db.user = "root"
 #crossdata-core.catalog.jdbc.db.pass = "stratio"
+#crossdata-core.catalog.clustername = "crossdataCluster"
 
 
 ####### PostgreSQL ###########
 #crossdata-core.catalog.class = "org.apache.spark.sql.crossdata.catalog.PostgreSQLCatalog"
 #crossdata-core.catalog.jdbc.driver = "org.postgresql.Driver"
 #crossdata-core.catalog.jdbc.url = "jdbc:postgresql://127.0.0.1:5432/"
-#crossdata-core.catalog.jdbc.db.name = "crossdata"
-#crossdata-core.catalog.jdbc.db.table = "crossdataTables"
-#crossdata-core.catalog.jdbc.db.view = "crossdataViews"
-#crossdata-core.catalog.jdbc.db.index = "crossdataIndexes"
-#crossdata-core.catalog.jdbc.db.app = "crossdataJars"
 #crossdata-core.catalog.jdbc.db.user = "postgres"
 #crossdata-core.catalog.jdbc.db.pass = "postgres"
+#crossdata-core.catalog.clustername = "crossdataCluster"
 
 
 ####### Zookeeper Catalog Configuration ###########
@@ -52,6 +45,7 @@ crossdata-core.launcher.sparkHome=${?crossdata_core_launcher_spark_home}
 #crossdata-core.catalog.zookeeper.sessionTimeout = 60000
 #crossdata-core.catalog.zookeeper.retryAttempts = 5
 #crossdata-core.catalog.zookeeper.retryInterval = 10000
+#crossdata-core.catalog.clustername = "crossdataCluster"
 
 #####################################
 #                                   #

--- a/core/src/main/resources/core-reference.conf
+++ b/core/src/main/resources/core-reference.conf
@@ -26,6 +26,8 @@ crossdata-core.launcher.sparkHome=${?crossdata_core_launcher_spark_home}
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
 #crossdata-core.catalog.jdbc.db.table = "crossdataTables"
 #crossdata-core.catalog.jdbc.db.view = "crossdataViews"
+#crossdata-core.catalog.jdbc.db.index = "crossdataIndexes"
+#crossdata-core.catalog.jdbc.db.app = "crossdataJars"
 #crossdata-core.catalog.jdbc.db.user = "root"
 #crossdata-core.catalog.jdbc.db.pass = "stratio"
 
@@ -37,6 +39,8 @@ crossdata-core.launcher.sparkHome=${?crossdata_core_launcher_spark_home}
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
 #crossdata-core.catalog.jdbc.db.table = "crossdataTables"
 #crossdata-core.catalog.jdbc.db.view = "crossdataViews"
+#crossdata-core.catalog.jdbc.db.index = "crossdataIndexes"
+#crossdata-core.catalog.jdbc.db.app = "crossdataJars"
 #crossdata-core.catalog.jdbc.db.user = "postgres"
 #crossdata-core.catalog.jdbc.db.pass = "postgres"
 

--- a/core/src/main/resources/core-reference.conf
+++ b/core/src/main/resources/core-reference.conf
@@ -78,7 +78,7 @@ crossdata-core.jars.externalJars = ${?crossdata_hdfs_externaljars}
 //crossdata-core.streaming.catalog.zookeeper.sessionTimeout = 60000
 //crossdata-core.streaming.catalog.zookeeper.retryAttempts = 5
 //crossdata-core.streaming.catalog.zookeeper.retryInterval = 10000
-//crossdata-core.streaming.catalog.prefix = "crossdataCluster"
+//crossdata-core.streaming.catalog.zookeeper.prefix = "crossdataCluster"
 //
 //
 //

--- a/core/src/main/resources/core-reference.conf
+++ b/core/src/main/resources/core-reference.conf
@@ -26,7 +26,7 @@ crossdata-core.launcher.sparkHome=${?crossdata_core_launcher_spark_home}
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
 #crossdata-core.catalog.jdbc.db.user = "root"
 #crossdata-core.catalog.jdbc.db.pass = "stratio"
-#crossdata-core.catalog.clustername = "crossdataCluster"
+#crossdata-core.catalog.prefix = "crossdataCluster"
 
 
 ####### PostgreSQL ###########
@@ -35,7 +35,7 @@ crossdata-core.launcher.sparkHome=${?crossdata_core_launcher_spark_home}
 #crossdata-core.catalog.jdbc.url = "jdbc:postgresql://127.0.0.1:5432/"
 #crossdata-core.catalog.jdbc.db.user = "postgres"
 #crossdata-core.catalog.jdbc.db.pass = "postgres"
-#crossdata-core.catalog.clustername = "crossdataCluster"
+#crossdata-core.catalog.prefix = "crossdataCluster"
 
 
 ####### Zookeeper Catalog Configuration ###########
@@ -45,7 +45,7 @@ crossdata-core.launcher.sparkHome=${?crossdata_core_launcher_spark_home}
 #crossdata-core.catalog.zookeeper.sessionTimeout = 60000
 #crossdata-core.catalog.zookeeper.retryAttempts = 5
 #crossdata-core.catalog.zookeeper.retryInterval = 10000
-#crossdata-core.catalog.clustername = "crossdataCluster"
+#crossdata-core.catalog.prefix = "crossdataCluster"
 
 #####################################
 #                                   #
@@ -78,6 +78,7 @@ crossdata-core.jars.externalJars = ${?crossdata_hdfs_externaljars}
 //crossdata-core.streaming.catalog.zookeeper.sessionTimeout = 60000
 //crossdata-core.streaming.catalog.zookeeper.retryAttempts = 5
 //crossdata-core.streaming.catalog.zookeeper.retryInterval = 10000
+//crossdata-core.streaming.catalog.prefix = "crossdataCluster"
 //
 //
 //

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
@@ -81,7 +81,7 @@ class MySQLXDCatalog(override val catalystConf: CatalystConf)
 
   protected lazy val config = XDContext.catalogConfig
   private lazy val db = config.getString(Database)
-  protected lazy val tablesPrefix = Try(s"${config.getString(PrefixConfig)}_") getOrElse ("") //clustername_
+  protected lazy val tablesPrefix = Try(s"${config.getString(PrefixConfig)}_") getOrElse ("") //prefix_
   protected lazy val tableWithTableMetadata = s"$tablesPrefix$DefaultTablesMetadataTable"
   protected lazy val tableWithViewMetadata = s"$tablesPrefix$DefaultViewsMetadataTable"
   protected lazy val tableWithAppJars = s"$tablesPrefix$DefaultAppsMetadataTable"

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
@@ -28,12 +28,12 @@ import scala.util.Try
 
 object MySQLXDCatalog {
   // SQLConfig
-  val Driver = "crossdata-core.jdbc.driver"
-  val Url = "crossdata-core.jdbc.url"
-  val Database = "crossdata-core.jdbc.db.name"
-  val User = "crossdata-core.jdbc.db.user"
-  val Pass = "crossdata-core.jdbc.db.pass"
-  val ClusterNameConfig = "crossdata-core.catalog.clustername"
+  val Driver = "jdbc.driver"
+  val Url = "jdbc.url"
+  val Database = "jdbc.db.name"
+  val User = "jdbc.db.user"
+  val Pass = "jdbc.db.pass"
+  val PrefixConfig = "prefix"
 
   //Default tables
   val DefaultTablesMetadataTable = "crossdataTables"
@@ -81,7 +81,7 @@ class MySQLXDCatalog(override val catalystConf: CatalystConf)
 
   protected lazy val config = XDContext.catalogConfig
   private lazy val db = config.getString(Database)
-  protected lazy val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
+  protected lazy val tablesPrefix = Try(s"${config.getString(PrefixConfig)}_") getOrElse ("") //clustername_
   protected lazy val tableWithTableMetadata = s"$tablesPrefix$DefaultTablesMetadataTable"
   protected lazy val tableWithViewMetadata = s"$tablesPrefix$DefaultViewsMetadataTable"
   protected lazy val tableWithAppJars = s"$tablesPrefix$DefaultAppsMetadataTable"

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
@@ -21,21 +21,25 @@ import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.{CatalystConf, TableIdentifier}
 import org.apache.spark.sql.crossdata.{CrossdataVersion, XDContext}
 import org.apache.spark.sql.crossdata.catalog.interfaces.XDAppsCatalog
-import org.apache.spark.sql.crossdata.catalog.{IndexIdentifierNormalized, TableIdentifierNormalized, StringNormalized, XDCatalog, persistent}
+import org.apache.spark.sql.crossdata.catalog.{IndexIdentifierNormalized, StringNormalized, TableIdentifierNormalized, XDCatalog, persistent}
 
 import scala.annotation.tailrec
+import scala.util.Try
 
 object MySQLXDCatalog {
   // SQLConfig
   val Driver = "jdbc.driver"
   val Url = "jdbc.url"
   val Database = "jdbc.db.name"
-  val TableWithTableMetadataConfig = "jdbc.db.table"
-  val TableWithViewMetadataConfig = "jdbc.db.view"
-  val TableWithAppMetadataConfig = "jdbc.db.app"
-  val TableWithIndexMetadataConfig = "jdbc.db.index"
   val User = "jdbc.db.user"
   val Pass = "jdbc.db.pass"
+  val ClusterNameConfig = "clustername"
+
+  //Default tables
+  val DefaultTablesMetadataTable = "crossdataTables"
+  val DefaultViewsMetadataTable = "crossdataViews"
+  val DefaultAppsMetadataTable = "crossdataJars"
+  val DefaultIndexesMetadataTable = "crossdataIndexes"
 
   // CatalogFields
   val DatabaseField = "db"
@@ -77,10 +81,11 @@ class MySQLXDCatalog(override val catalystConf: CatalystConf)
 
   private val config = XDContext.catalogConfig
   private val db = config.getString(Database)
-  private val tableWithTableMetadata = config.getString(TableWithTableMetadataConfig)
-  private val tableWithViewMetadata = config.getString(TableWithViewMetadataConfig)
-  private val tableWithAppJars = config.getString(TableWithAppMetadataConfig)
-  private val tableWithIndexMetadata = config.getString(TableWithIndexMetadataConfig)
+  private val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
+  private val tableWithTableMetadata = s"${tablesPrefix}_$DefaultTablesMetadataTable"
+  private val tableWithViewMetadata = s"${tablesPrefix}_$DefaultViewsMetadataTable"
+  private val tableWithAppJars = s"${tablesPrefix}_$DefaultAppsMetadataTable"
+  private val tableWithIndexMetadata = s"${tablesPrefix}_$DefaultIndexesMetadataTable"
 
   @transient lazy val connection: Connection = {
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
@@ -79,13 +79,13 @@ class MySQLXDCatalog(override val catalystConf: CatalystConf)
   import XDCatalog._
 
 
-  protected[crossdata] lazy val config = XDContext.catalogConfig
-  protected[crossdata] lazy val db = config.getString(Database)
-  protected[crossdata] lazy val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
-  protected[crossdata] lazy val tableWithTableMetadata = s"$tablesPrefix$DefaultTablesMetadataTable"
-  protected[crossdata] lazy val tableWithViewMetadata = s"$tablesPrefix$DefaultViewsMetadataTable"
-  protected[crossdata] lazy val tableWithAppJars = s"$tablesPrefix$DefaultAppsMetadataTable"
-  protected[crossdata] lazy val tableWithIndexMetadata = s"$tablesPrefix$DefaultIndexesMetadataTable"
+  protected lazy val config = XDContext.catalogConfig
+  private lazy val db = config.getString(Database)
+  protected lazy val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
+  protected lazy val tableWithTableMetadata = s"$tablesPrefix$DefaultTablesMetadataTable"
+  protected lazy val tableWithViewMetadata = s"$tablesPrefix$DefaultViewsMetadataTable"
+  protected lazy val tableWithAppJars = s"$tablesPrefix$DefaultAppsMetadataTable"
+  protected lazy val tableWithIndexMetadata = s"$tablesPrefix$DefaultIndexesMetadataTable"
 
   @transient lazy val connection: Connection = {
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
@@ -33,7 +33,7 @@ object MySQLXDCatalog {
   val TableWithTableMetadataConfig = "jdbc.db.table"
   val TableWithViewMetadataConfig = "jdbc.db.view"
   val TableWithAppMetadataConfig = "jdbc.db.app"
-  val TableWithIndexMetadataConfig = "jdbc.db.indexes"
+  val TableWithIndexMetadataConfig = "jdbc.db.index"
   val User = "jdbc.db.user"
   val Pass = "jdbc.db.pass"
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLXDCatalog.scala
@@ -28,12 +28,12 @@ import scala.util.Try
 
 object MySQLXDCatalog {
   // SQLConfig
-  val Driver = "jdbc.driver"
-  val Url = "jdbc.url"
-  val Database = "jdbc.db.name"
-  val User = "jdbc.db.user"
-  val Pass = "jdbc.db.pass"
-  val ClusterNameConfig = "clustername"
+  val Driver = "crossdata-core.jdbc.driver"
+  val Url = "crossdata-core.jdbc.url"
+  val Database = "crossdata-core.jdbc.db.name"
+  val User = "crossdata-core.jdbc.db.user"
+  val Pass = "crossdata-core.jdbc.db.pass"
+  val ClusterNameConfig = "crossdata-core.catalog.clustername"
 
   //Default tables
   val DefaultTablesMetadataTable = "crossdataTables"
@@ -79,13 +79,13 @@ class MySQLXDCatalog(override val catalystConf: CatalystConf)
   import XDCatalog._
 
 
-  private val config = XDContext.catalogConfig
-  private val db = config.getString(Database)
-  private val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
-  private val tableWithTableMetadata = s"${tablesPrefix}_$DefaultTablesMetadataTable"
-  private val tableWithViewMetadata = s"${tablesPrefix}_$DefaultViewsMetadataTable"
-  private val tableWithAppJars = s"${tablesPrefix}_$DefaultAppsMetadataTable"
-  private val tableWithIndexMetadata = s"${tablesPrefix}_$DefaultIndexesMetadataTable"
+  protected[crossdata] lazy val config = XDContext.catalogConfig
+  protected[crossdata] lazy val db = config.getString(Database)
+  protected[crossdata] lazy val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
+  protected[crossdata] lazy val tableWithTableMetadata = s"$tablesPrefix$DefaultTablesMetadataTable"
+  protected[crossdata] lazy val tableWithViewMetadata = s"$tablesPrefix$DefaultViewsMetadataTable"
+  protected[crossdata] lazy val tableWithAppJars = s"$tablesPrefix$DefaultAppsMetadataTable"
+  protected[crossdata] lazy val tableWithIndexMetadata = s"$tablesPrefix$DefaultIndexesMetadataTable"
 
   @transient lazy val connection: Connection = {
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
@@ -31,9 +31,9 @@ object PostgreSQLXDCatalog {
   val Url = "jdbc.url"
   val Database = "jdbc.db.name"
   val Table = "jdbc.db.table"
-  val TableWithViewMetadata = "jdbc.db.view"
-  val TableWithAppMetadata = "jdbc.db.app"
-  val TableWithIndexMetadata = "jdbc.db.index"
+  val TableWithViewMetadataConfig = "jdbc.db.view"
+  val TableWithAppMetadataConfig = "jdbc.db.app"
+  val TableWithIndexMetadataConfig = "jdbc.db.index"
   val User = "jdbc.db.user"
   val Pass = "jdbc.db.pass"
 
@@ -77,8 +77,9 @@ class PostgreSQLXDCatalog(sqlContext: SQLContext, override val catalystConf: Cat
 
   private val db = config.getString(Database)
   private val table = config.getString(Table)
-  private val tableWithViewMetadata = config.getString(TableWithViewMetadata)
-  private val tableWithAppJars = config.getString(TableWithAppMetadata)
+  private val tableWithViewMetadata = config.getString(TableWithViewMetadataConfig)
+  private val tableWithAppJars = config.getString(TableWithAppMetadataConfig)
+  private val tableWithIndexMetadata = config.getString(TableWithIndexMetadataConfig)
 
   @transient lazy val connection: Connection = {
 
@@ -122,7 +123,7 @@ class PostgreSQLXDCatalog(sqlContext: SQLContext, override val catalystConf: Cat
             |PRIMARY KEY ($AppAlias))""".stripMargin)
 
       jdbcConnection.createStatement().executeUpdate(
-        s"""|CREATE TABLE IF NOT EXISTS $db.$TableWithIndexMetadata (
+        s"""|CREATE TABLE IF NOT EXISTS $db.$tableWithIndexMetadata (
             |$DatabaseField VARCHAR(50),
             |$TableNameField VARCHAR(50),
             |$IndexNameField VARCHAR(50),
@@ -391,14 +392,14 @@ class PostgreSQLXDCatalog(sqlContext: SQLContext, override val catalystConf: Cat
     try {
       connection.setAutoCommit(false)
       // check if the database-table exist in the persisted catalog
-      val resultSet = selectMetadata(TableWithIndexMetadata, crossdataIndex.tableIdentifier)
+      val resultSet = selectMetadata(tableWithIndexMetadata, crossdataIndex.tableIdentifier)
 
       val serializedIndexedCols = serializeSeq(crossdataIndex.indexedCols)
       val serializedOptions = serializeOptions(crossdataIndex.opts)
 
       if (!resultSet.next()) {
         val prepped = connection.prepareStatement(
-          s"""|INSERT INTO $db.$TableWithIndexMetadata (
+          s"""|INSERT INTO $db.$tableWithIndexMetadata (
               | $DatabaseField, $TableNameField, $IndexNameField, $IndexTypeField, $IndexedColsField,
               | $PKField, $DatasourceField, $OptionsField, $CrossdataVersionField
               |) VALUES (?,?,?,?,?,?,?,?,?)
@@ -424,11 +425,11 @@ class PostgreSQLXDCatalog(sqlContext: SQLContext, override val catalystConf: Cat
 
   override def dropIndexMetadata(indexIdentifier: IndexIdentifierNormalized): Unit =
     connection.createStatement.executeUpdate(
-      s"DELETE FROM $db.$TableWithIndexMetadata WHERE $IndexTypeField='${indexIdentifier.indexType}' AND $IndexNameField='${indexIdentifier.indexName}'"
+      s"DELETE FROM $db.$tableWithIndexMetadata WHERE $IndexTypeField='${indexIdentifier.indexType}' AND $IndexNameField='${indexIdentifier.indexName}'"
     )
 
   override def dropAllIndexesMetadata(): Unit =
-    connection.createStatement.executeUpdate(s"DELETE FROM $db.$TableWithIndexMetadata")
+    connection.createStatement.executeUpdate(s"DELETE FROM $db.$tableWithIndexMetadata")
 
   override def lookupIndex(indexIdentifier: IndexIdentifierNormalized): Option[CrossdataIndex] = {
     val resultSet = selectIndex(indexIdentifier)
@@ -455,7 +456,7 @@ class PostgreSQLXDCatalog(sqlContext: SQLContext, override val catalystConf: Cat
   }
 
   private def selectIndex(indexIdentifier: IndexIdentifierNormalized): ResultSet = {
-    val preparedStatement = connection.prepareStatement(s"SELECT * FROM $db.$TableWithIndexMetadata WHERE $IndexNameField= ? AND $IndexTypeField= ?")
+    val preparedStatement = connection.prepareStatement(s"SELECT * FROM $db.$tableWithIndexMetadata WHERE $IndexNameField= ? AND $IndexTypeField= ?")
     preparedStatement.setString(1, indexIdentifier.indexName)
     preparedStatement.setString(2, indexIdentifier.indexType)
     preparedStatement.executeQuery()
@@ -463,12 +464,12 @@ class PostgreSQLXDCatalog(sqlContext: SQLContext, override val catalystConf: Cat
 
   override def dropIndexMetadata(tableIdentifier: TableIdentifierNormalized): Unit =
     connection.createStatement.executeUpdate(
-      s"DELETE FROM $db.$TableWithIndexMetadata WHERE $TableNameField='${tableIdentifier.table}' AND $DatabaseField='${tableIdentifier.database.getOrElse("")}'"
+      s"DELETE FROM $db.$tableWithIndexMetadata WHERE $TableNameField='${tableIdentifier.table}' AND $DatabaseField='${tableIdentifier.database.getOrElse("")}'"
     )
 
   override def lookupIndexByTableIdentifier(tableIdentifier: TableIdentifierNormalized): Option[CrossdataIndex] = {
     val query =
-      s"SELECT * FROM $db.$TableWithIndexMetadata WHERE $TableNameField='${tableIdentifier.table}' AND $DatabaseField='${tableIdentifier.database.getOrElse("")}'"
+      s"SELECT * FROM $db.$tableWithIndexMetadata WHERE $TableNameField='${tableIdentifier.table}' AND $DatabaseField='${tableIdentifier.database.getOrElse("")}'"
     val preparedStatement = connection.prepareStatement(query)
     val resultSet = preparedStatement.executeQuery()
     if (!resultSet.next) {

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
@@ -28,12 +28,12 @@ import scala.util.Try
 
 object PostgreSQLXDCatalog {
   // SQLConfig
-  val Driver = "crossdata-core.catalog.jdbc.driver"
-  val Url = "crossdata-core.catalog.jdbc.url"
-  val Database = "crossdata-core.catalog.jdbc.db.name"
-  val User = "crossdata-core.catalog.jdbc.db.user"
-  val Pass = "crossdata-core.catalog.jdbc.db.pass"
-  val ClusterNameConfig = "crossdata-core.catalog.clustername"
+  val Driver = "jdbc.driver"
+  val Url = "jdbc.url"
+  val Database = "jdbc.db.name"
+  val User = "jdbc.db.user"
+  val Pass = "jdbc.db.pass"
+  val PrefixConfig = "prefix"
 
   //Default tables
   val DefaultTablesMetadataTable = "crossdataTables"
@@ -80,7 +80,7 @@ class PostgreSQLXDCatalog(override val catalystConf: CatalystConf)
   protected lazy val config = XDContext.catalogConfig
 
   private lazy val db = config.getString(Database)
-  protected lazy val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
+  protected lazy val tablesPrefix = Try(s"${config.getString(PrefixConfig)}_") getOrElse ("") //clustername_
   protected lazy val tableWithTableMetadata = s"$tablesPrefix$DefaultTablesMetadataTable"
   protected lazy val tableWithViewMetadata = s"$tablesPrefix$DefaultViewsMetadataTable"
   protected lazy val tableWithAppJars = s"$tablesPrefix$DefaultAppsMetadataTable"

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
@@ -77,14 +77,14 @@ class PostgreSQLXDCatalog(override val catalystConf: CatalystConf)
   import PostgreSQLXDCatalog._
   import XDCatalog._
 
-  protected[crossdata] lazy val config = XDContext.catalogConfig
+  protected lazy val config = XDContext.catalogConfig
 
-  protected[crossdata] lazy val db = config.getString(Database)
-  protected[crossdata] lazy val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
-  protected[crossdata] lazy val tableWithTableMetadata = s"$tablesPrefix$DefaultTablesMetadataTable"
-  protected[crossdata] lazy val tableWithViewMetadata = s"$tablesPrefix$DefaultViewsMetadataTable"
-  protected[crossdata] lazy val tableWithAppJars = s"$tablesPrefix$DefaultAppsMetadataTable"
-  protected[crossdata] lazy val tableWithIndexMetadata = s"$tablesPrefix$DefaultIndexesMetadataTable"
+  private lazy val db = config.getString(Database)
+  protected lazy val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
+  protected lazy val tableWithTableMetadata = s"$tablesPrefix$DefaultTablesMetadataTable"
+  protected lazy val tableWithViewMetadata = s"$tablesPrefix$DefaultViewsMetadataTable"
+  protected lazy val tableWithAppJars = s"$tablesPrefix$DefaultAppsMetadataTable"
+  protected lazy val tableWithIndexMetadata = s"$tablesPrefix$DefaultIndexesMetadataTable"
 
   @transient lazy val connection: Connection = {
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
@@ -77,7 +77,7 @@ class PostgreSQLXDCatalog(sqlContext: SQLContext, override val catalystConf: Cat
   import PostgreSQLXDCatalog._
   import XDCatalog._
 
-  private val config = XDContext.catalogConfig
+  protected[crossdata] val config = XDContext.catalogConfig
 
   private val db = config.getString(Database)
   private val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
@@ -80,7 +80,7 @@ class PostgreSQLXDCatalog(override val catalystConf: CatalystConf)
   protected lazy val config = XDContext.catalogConfig
 
   private lazy val db = config.getString(Database)
-  protected lazy val tablesPrefix = Try(s"${config.getString(PrefixConfig)}_") getOrElse ("") //clustername_
+  protected lazy val tablesPrefix = Try(s"${config.getString(PrefixConfig)}_") getOrElse ("") //prefix_
   protected lazy val tableWithTableMetadata = s"$tablesPrefix$DefaultTablesMetadataTable"
   protected lazy val tableWithViewMetadata = s"$tablesPrefix$DefaultViewsMetadataTable"
   protected lazy val tableWithAppJars = s"$tablesPrefix$DefaultAppsMetadataTable"

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
@@ -28,12 +28,12 @@ import scala.util.Try
 
 object PostgreSQLXDCatalog {
   // SQLConfig
-  val Driver = "jdbc.driver"
-  val Url = "jdbc.url"
-  val Database = "jdbc.db.name"
-  val User = "jdbc.db.user"
-  val Pass = "jdbc.db.pass"
-  val ClusterNameConfig = "clustername"
+  val Driver = "crossdata-core.catalog.jdbc.driver"
+  val Url = "crossdata-core.catalog.jdbc.url"
+  val Database = "crossdata-core.catalog.jdbc.db.name"
+  val User = "crossdata-core.catalog.jdbc.db.user"
+  val Pass = "crossdata-core.catalog.jdbc.db.pass"
+  val ClusterNameConfig = "crossdata-core.catalog.clustername"
 
   //Default tables
   val DefaultTablesMetadataTable = "crossdataTables"
@@ -71,20 +71,20 @@ object PostgreSQLXDCatalog {
   *
   * @param catalystConf An implementation of the [[CatalystConf]].
   */
-class PostgreSQLXDCatalog(sqlContext: SQLContext, override val catalystConf: CatalystConf)
+class PostgreSQLXDCatalog(override val catalystConf: CatalystConf)
   extends PersistentCatalogWithCache(catalystConf) {
 
   import PostgreSQLXDCatalog._
   import XDCatalog._
 
-  protected[crossdata] val config = XDContext.catalogConfig
+  protected[crossdata] lazy val config = XDContext.catalogConfig
 
-  private val db = config.getString(Database)
-  private val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
-  private val tableWithTableMetadata = s"${tablesPrefix}_$DefaultTablesMetadataTable"
-  private val tableWithViewMetadata = s"${tablesPrefix}_$DefaultViewsMetadataTable"
-  private val tableWithAppJars = s"${tablesPrefix}_$DefaultAppsMetadataTable"
-  private val tableWithIndexMetadata = s"${tablesPrefix}_$DefaultIndexesMetadataTable"
+  protected[crossdata] lazy val db = config.getString(Database)
+  protected[crossdata] lazy val tablesPrefix = Try(s"${config.getString(ClusterNameConfig)}_") getOrElse ("") //clustername_
+  protected[crossdata] lazy val tableWithTableMetadata = s"$tablesPrefix$DefaultTablesMetadataTable"
+  protected[crossdata] lazy val tableWithViewMetadata = s"$tablesPrefix$DefaultViewsMetadataTable"
+  protected[crossdata] lazy val tableWithAppJars = s"$tablesPrefix$DefaultAppsMetadataTable"
+  protected[crossdata] lazy val tableWithIndexMetadata = s"$tablesPrefix$DefaultIndexesMetadataTable"
 
   @transient lazy val connection: Connection = {
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLXDCatalog.scala
@@ -30,7 +30,7 @@ object PostgreSQLXDCatalog {
   val Driver = "jdbc.driver"
   val Url = "jdbc.url"
   val Database = "jdbc.db.name"
-  val Table = "jdbc.db.table"
+  val TableWithTableMetadataConfig = "jdbc.db.table"
   val TableWithViewMetadataConfig = "jdbc.db.view"
   val TableWithAppMetadataConfig = "jdbc.db.app"
   val TableWithIndexMetadataConfig = "jdbc.db.index"
@@ -76,7 +76,7 @@ class PostgreSQLXDCatalog(sqlContext: SQLContext, override val catalystConf: Cat
   private val config = XDContext.catalogConfig
 
   private val db = config.getString(Database)
-  private val table = config.getString(Table)
+  private val table = config.getString(TableWithTableMetadataConfig)
   private val tableWithViewMetadata = config.getString(TableWithViewMetadataConfig)
   private val tableWithAppJars = config.getString(TableWithAppMetadataConfig)
   private val tableWithIndexMetadata = config.getString(TableWithIndexMetadataConfig)

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/ZookeeperCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalog/persistent/ZookeeperCatalog.scala
@@ -18,9 +18,10 @@ package org.apache.spark.sql.crossdata.catalog.persistent
 
 import java.net.Socket
 
+import com.typesafe.config.Config
 import org.apache.spark.sql.catalyst.{CatalystConf, TableIdentifier}
 import org.apache.spark.sql.crossdata.XDContext
-import org.apache.spark.sql.crossdata.catalog.{IndexIdentifierNormalized, TableIdentifierNormalized, StringNormalized, XDCatalog, persistent}
+import org.apache.spark.sql.crossdata.catalog.{IndexIdentifierNormalized, StringNormalized, TableIdentifierNormalized, XDCatalog, persistent}
 import org.apache.spark.sql.crossdata.daos.DAOConstants._
 import org.apache.spark.sql.crossdata.daos.impl.{AppTypesafeDAO, IndexTypesafeDAO, TableTypesafeDAO, ViewTypesafeDAO}
 import org.apache.spark.sql.crossdata.models.{AppModel, IndexModel, TableModel, ViewModel}
@@ -38,10 +39,11 @@ class ZookeeperCatalog(override val catalystConf: CatalystConf)
 
   import XDCatalog._
 
-  @transient val tableDAO = new TableTypesafeDAO(XDContext.catalogConfig)
-  @transient val viewDAO = new ViewTypesafeDAO(XDContext.catalogConfig)
-  @transient val appDAO = new AppTypesafeDAO(XDContext.catalogConfig)
-  @transient val indexDAO = new IndexTypesafeDAO(XDContext.catalogConfig)
+  protected[crossdata] lazy val config: Config = XDContext.catalogConfig
+  @transient lazy val tableDAO = new TableTypesafeDAO(config)
+  @transient lazy val viewDAO = new ViewTypesafeDAO(config)
+  @transient lazy val appDAO = new AppTypesafeDAO(config)
+  @transient lazy val indexDAO = new IndexTypesafeDAO(config)
 
 
   override def lookupTable(tableIdentifier: TableIdentifierNormalized): Option[CrossdataTable] = {

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/AppDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/AppDAO.scala
@@ -42,5 +42,5 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(prefix+AppsPath))
+  override val dao: DAO = new GenericDAO(Option(s"$BaseZKPath/$prefix$AppsPath"))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/AppDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/AppDAO.scala
@@ -40,8 +40,6 @@ import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 trait AppDAO extends GenericDAOComponent[AppModel]
 with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
-  val appID = "appID"
-
   override implicit val formats = json4sJacksonFormats
 
   override val dao: DAO = new GenericDAO(Option(AppsPath))

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/AppDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/AppDAO.scala
@@ -38,9 +38,9 @@ import org.apache.spark.sql.crossdata.models.{AppModel, ViewModel}
 import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 
 trait AppDAO extends GenericDAOComponent[AppModel]
-with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
+with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer with PrefixedDAO {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+AppsPath))
+  override val dao: DAO = new GenericDAO(Option(prefix+AppsPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/AppDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/AppDAO.scala
@@ -42,5 +42,5 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(AppsPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+AppsPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/DAOConstants.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/DAOConstants.scala
@@ -19,7 +19,8 @@ import java.util.UUID
 
 object DAOConstants {
 
-  val ClusterNameConfig = "catalog.clustername"
+  val PrefixPermantCatalogsConfig = "prefix" //crossdata-core.catalog.prefix
+  val PrefixStreamingCatalogsConfig = "prefix" //crossdata-core.streaming.catalog.prefix
 
   val BaseZKPath = "stratio/crossdata"
   val TablesPath = s"$BaseZKPath/tables"

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/DAOConstants.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/DAOConstants.scala
@@ -23,13 +23,13 @@ object DAOConstants {
   val PrefixStreamingCatalogsConfig = "zookeeper.prefix" //crossdata-core.streaming.catalog.zookeeper.prefix
 
   val BaseZKPath = "stratio/crossdata"
-  val TablesPath = s"$BaseZKPath/tables"
-  val ViewsPath = s"$BaseZKPath/views"
-  val AppsPath = s"$BaseZKPath/apps"
-  val IndexesPath = s"$BaseZKPath/indexes"
-  val EphemeralTablesPath = s"$BaseZKPath/ephemeraltables"
-  val EphemeralTableStatusPath = s"$BaseZKPath/ephemeraltablestatus"
-  val EphemeralQueriesPath = s"$BaseZKPath/ephemeralqueries"
+  val TablesPath = "tables"
+  val ViewsPath = "views"
+  val AppsPath = "apps"
+  val IndexesPath = "indexes"
+  val EphemeralTablesPath = "ephemeraltables"
+  val EphemeralTableStatusPath = "ephemeraltablestatus"
+  val EphemeralQueriesPath = "ephemeralqueries"
 
   def createId: String = UUID.randomUUID.toString
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/DAOConstants.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/DAOConstants.scala
@@ -20,6 +20,7 @@ import java.util.UUID
 object DAOConstants {
 
   val PrefixPermantCatalogsConfig = "prefix" //crossdata-core.catalog.prefix
+  val PrefixStreamingCatalogsConfigForActors = "prefix" //crossdata-core.streaming.catalog.zookeeper.prefix
   val PrefixStreamingCatalogsConfig = "zookeeper.prefix" //crossdata-core.streaming.catalog.zookeeper.prefix
 
   val BaseZKPath = "stratio/crossdata"

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/DAOConstants.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/DAOConstants.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 object DAOConstants {
 
   val PrefixPermantCatalogsConfig = "prefix" //crossdata-core.catalog.prefix
-  val PrefixStreamingCatalogsConfig = "prefix" //crossdata-core.streaming.catalog.prefix
+  val PrefixStreamingCatalogsConfig = "zookeeper.prefix" //crossdata-core.streaming.catalog.zookeeper.prefix
 
   val BaseZKPath = "stratio/crossdata"
   val TablesPath = s"$BaseZKPath/tables"

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/DAOConstants.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/DAOConstants.scala
@@ -19,6 +19,8 @@ import java.util.UUID
 
 object DAOConstants {
 
+  val ClusterNameConfig = "catalog.clustername"
+
   val BaseZKPath = "stratio/crossdata"
   val TablesPath = s"$BaseZKPath/tables"
   val ViewsPath = s"$BaseZKPath/views"

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesDAO.scala
@@ -26,8 +26,7 @@ import org.json4s.Formats
 trait EphemeralQueriesDAO extends GenericDAOComponent[EphemeralQueryModel]
 with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
-  private val jacksonFormats: Formats = json4sJacksonFormats
-  override implicit val formats = jacksonFormats
+  override implicit val formats = json4sJacksonFormats
 
   override val dao: DAO = new GenericDAO(Option(EphemeralQueriesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesDAO.scala
@@ -28,5 +28,5 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(EphemeralQueriesPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralQueriesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesDAO.scala
@@ -24,9 +24,9 @@ import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 import org.json4s.Formats
 
 trait EphemeralQueriesDAO extends GenericDAOComponent[EphemeralQueryModel]
-with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
+with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer with PrefixedDAO{
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralQueriesPath))
+  override val dao: DAO = new GenericDAO(Option(prefix+EphemeralQueriesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesDAO.scala
@@ -28,5 +28,5 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(prefix+EphemeralQueriesPath))
+  override val dao: DAO = new GenericDAO(Option(s"$BaseZKPath/$prefix$EphemeralQueriesPath"))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesMapDAO.scala
@@ -27,5 +27,5 @@ with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(EphemeralQueriesPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralQueriesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesMapDAO.scala
@@ -27,5 +27,5 @@ with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralQueriesPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(PrefixStreamingCatalogsConfig,"")+"_"+EphemeralQueriesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesMapDAO.scala
@@ -23,9 +23,9 @@ import org.apache.spark.sql.crossdata.models.EphemeralQueryModel
 import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 
 trait EphemeralQueriesMapDAO extends GenericDAOComponent[EphemeralQueryModel]
-with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer {
+with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer with PrefixedDAO {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(PrefixStreamingCatalogsConfig,"")+"_"+EphemeralQueriesPath))
+  override val dao: DAO = new GenericDAO(Option(prefix+EphemeralQueriesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralQueriesMapDAO.scala
@@ -27,5 +27,5 @@ with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer with 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(prefix+EphemeralQueriesPath))
+  override val dao: DAO = new GenericDAO(Option(s"$BaseZKPath/$prefix$EphemeralQueriesPath"))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableDAO.scala
@@ -25,8 +25,6 @@ import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 trait EphemeralTableDAO extends GenericDAOComponent[EphemeralTableModel]
 with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
-  val ephemeralTableIdField = "EphemeralTableID"
-
   override implicit val formats = json4sJacksonFormats
 
   override val dao: DAO = new GenericDAO(Option(EphemeralTablesPath))

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableDAO.scala
@@ -27,5 +27,5 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(EphemeralTablesPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralTablesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableDAO.scala
@@ -23,9 +23,9 @@ import org.apache.spark.sql.crossdata.models.EphemeralTableModel
 import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 
 trait EphemeralTableDAO extends GenericDAOComponent[EphemeralTableModel]
-with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
+with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer with PrefixedDAO {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralTablesPath))
+  override val dao: DAO = new GenericDAO(Option(prefix+EphemeralTablesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableDAO.scala
@@ -27,5 +27,5 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(prefix+EphemeralTablesPath))
+  override val dao: DAO = new GenericDAO(Option(s"$BaseZKPath/$prefix$EphemeralTablesPath"))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableMapDAO.scala
@@ -27,5 +27,5 @@ with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(EphemeralTablesPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralTablesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableMapDAO.scala
@@ -27,5 +27,5 @@ with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer with 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(prefix+EphemeralTablesPath))
+  override val dao: DAO = new GenericDAO(Option(s"$BaseZKPath/$prefix$EphemeralTablesPath"))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableMapDAO.scala
@@ -27,5 +27,5 @@ with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralTablesPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(PrefixStreamingCatalogsConfig,"")+"_"+EphemeralTablesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableMapDAO.scala
@@ -23,9 +23,9 @@ import org.apache.spark.sql.crossdata.models.EphemeralTableModel
 import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 
 trait EphemeralTableMapDAO extends GenericDAOComponent[EphemeralTableModel]
-with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer {
+with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer with PrefixedDAO {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(PrefixStreamingCatalogsConfig,"")+"_"+EphemeralTablesPath))
+  override val dao: DAO = new GenericDAO(Option(prefix+EphemeralTablesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusDAO.scala
@@ -27,6 +27,6 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(prefix+EphemeralTableStatusPath))
+  override val dao: DAO = new GenericDAO(Option(s"$BaseZKPath/$prefix$EphemeralTableStatusPath"))
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusDAO.scala
@@ -23,10 +23,10 @@ import org.apache.spark.sql.crossdata.models.EphemeralStatusModel
 import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 
 trait EphemeralTableStatusDAO extends GenericDAOComponent[EphemeralStatusModel]
-with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
+with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer with PrefixedDAO {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralTableStatusPath))
+  override val dao: DAO = new GenericDAO(Option(prefix+EphemeralTableStatusPath))
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusDAO.scala
@@ -27,6 +27,6 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(EphemeralTableStatusPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralTableStatusPath))
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusMapDAO.scala
@@ -27,6 +27,6 @@ with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer with 
 
 override implicit val formats = json4sJacksonFormats
 
-override val dao: DAO = new GenericDAO(Option(prefix+EphemeralTableStatusPath))
+override val dao: DAO = new GenericDAO(Option(s"$BaseZKPath/$prefix$EphemeralTableStatusPath"))
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusMapDAO.scala
@@ -27,6 +27,6 @@ with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
 override implicit val formats = json4sJacksonFormats
 
-override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralTableStatusPath))
+override val dao: DAO = new GenericDAO(Option(config.getString(PrefixStreamingCatalogsConfig,"")+"_"+EphemeralTableStatusPath))
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusMapDAO.scala
@@ -23,10 +23,10 @@ import org.apache.spark.sql.crossdata.models.EphemeralStatusModel
 import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 
 trait EphemeralTableStatusMapDAO extends GenericDAOComponent[EphemeralStatusModel]
-with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer {
+with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer with PrefixedDAO {
 
 override implicit val formats = json4sJacksonFormats
 
-override val dao: DAO = new GenericDAO(Option(config.getString(PrefixStreamingCatalogsConfig,"")+"_"+EphemeralTableStatusPath))
+override val dao: DAO = new GenericDAO(Option(prefix+EphemeralTableStatusPath))
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/EphemeralTableStatusMapDAO.scala
@@ -27,6 +27,6 @@ with MapConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
 override implicit val formats = json4sJacksonFormats
 
-override val dao: DAO = new GenericDAO(Option(EphemeralTableStatusPath))
+override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+EphemeralTableStatusPath))
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/IndexDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/IndexDAO.scala
@@ -40,8 +40,6 @@ import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 trait IndexDAO extends GenericDAOComponent[IndexModel]
 with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
-  val indexID = "indexID"
-
   override implicit val formats = json4sJacksonFormats
 
   override val dao: DAO = new GenericDAO(Option(IndexesPath))

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/IndexDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/IndexDAO.scala
@@ -42,5 +42,5 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(IndexesPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+IndexesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/IndexDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/IndexDAO.scala
@@ -42,5 +42,5 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(prefix+IndexesPath))
+  override val dao: DAO = new GenericDAO(Option(s"$BaseZKPath/$prefix$IndexesPath"))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/IndexDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/IndexDAO.scala
@@ -38,9 +38,9 @@ import org.apache.spark.sql.crossdata.models.IndexModel
 import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 
 trait IndexDAO extends GenericDAOComponent[IndexModel]
-with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
+with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer with PrefixedDAO {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+IndexesPath))
+  override val dao: DAO = new GenericDAO(Option(prefix+IndexesPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/PrefixedDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/PrefixedDAO.scala
@@ -13,18 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.crossdata.daos.impl
+package org.apache.spark.sql.crossdata.daos
 
-import com.typesafe.config.Config
-import org.apache.spark.sql.crossdata.daos.DAOConstants._
-import org.apache.spark.sql.crossdata.daos.IndexDAO
-
-import scala.util.Try
-
-class IndexTypesafeDAO(configuration: Config) extends IndexDAO {
-
-  def prefix:String = Try(configuration.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
-
-  override val config = new TypesafeConfig(Option(configuration))
-
+/**
+  * Created by usarasola on 3/08/16.
+  */
+trait PrefixedDAO {
+  def prefix: String
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/PrefixedDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/PrefixedDAO.scala
@@ -15,9 +15,6 @@
  */
 package org.apache.spark.sql.crossdata.daos
 
-/**
-  * Created by usarasola on 3/08/16.
-  */
 trait PrefixedDAO {
   def prefix: String
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/TableDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/TableDAO.scala
@@ -28,6 +28,6 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(prefix+TablesPath))
+  override val dao: DAO = new GenericDAO(Option(s"$BaseZKPath/$prefix$TablesPath"))
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/TableDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/TableDAO.scala
@@ -28,6 +28,6 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+TablesPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+TablesPath)) //TODO Change
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/TableDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/TableDAO.scala
@@ -28,6 +28,6 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(TablesPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+TablesPath))
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/TableDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/TableDAO.scala
@@ -24,10 +24,10 @@ import org.apache.spark.sql.crossdata.models.TableModel
 import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 
 trait TableDAO extends GenericDAOComponent[TableModel]
-with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
+with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer with PrefixedDAO {
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+TablesPath)) //TODO Change
+  override val dao: DAO = new GenericDAO(Option(prefix+TablesPath))
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/TableDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/TableDAO.scala
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2015 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
 
 package org.apache.spark.sql.crossdata.daos
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/ViewDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/ViewDAO.scala
@@ -43,5 +43,5 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(prefix+ViewsPath))
+  override val dao: DAO = new GenericDAO(Option(s"$BaseZKPath/$prefix$ViewsPath"))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/ViewDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/ViewDAO.scala
@@ -43,5 +43,5 @@ with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(ViewsPath))
+  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+ViewsPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/ViewDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/ViewDAO.scala
@@ -38,10 +38,10 @@ import org.apache.spark.sql.crossdata.models.{ViewModel, EphemeralTableModel}
 import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 
 trait ViewDAO extends GenericDAOComponent[ViewModel]
-with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
+with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer with PrefixedDAO {
 
 
   override implicit val formats = json4sJacksonFormats
 
-  override val dao: DAO = new GenericDAO(Option(config.getString(ClusterNameConfig,"")+"_"+ViewsPath))
+  override val dao: DAO = new GenericDAO(Option(prefix+ViewsPath))
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/ViewDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/ViewDAO.scala
@@ -40,7 +40,6 @@ import org.apache.spark.sql.crossdata.serializers.CrossdataSerializer
 trait ViewDAO extends GenericDAOComponent[ViewModel]
 with TypesafeConfigComponent with SparkLoggerComponent with CrossdataSerializer {
 
-  val viewID = "viewID"
 
   override implicit val formats = json4sJacksonFormats
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/AppTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/AppTypesafeDAO.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 class AppTypesafeDAO(configuration: Config) extends AppDAO {
 
-  def prefix:String = Try(configuration.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
+  def prefix: String = Try(configuration.getString(PrefixPermantCatalogsConfig) + "_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/AppTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/AppTypesafeDAO.scala
@@ -17,8 +17,13 @@ package org.apache.spark.sql.crossdata.daos.impl
 
 import com.typesafe.config.Config
 import org.apache.spark.sql.crossdata.daos.AppDAO
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
+
+import scala.util.Try
 
 class AppTypesafeDAO(configuration: Config) extends AppDAO {
+
+  def prefix:String = Try(configuration.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralQueriesMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralQueriesMapDAO.scala
@@ -15,11 +15,16 @@
  */
 package org.apache.spark.sql.crossdata.daos.impl
 
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
 import org.apache.spark.sql.crossdata.daos.{EphemeralQueriesMapDAO => EphQueriesMapDAO}
+
+import scala.util.Try
 
 class EphemeralQueriesMapDAO(opts: Map[String, String], subPath: Option[String] = None)
   extends EphQueriesMapDAO{
 
   val memoryMap = opts
   override lazy val config: Config = new DummyConfig(subPath)
+
+  def prefix:String = Try(config.getString(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralQueriesMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralQueriesMapDAO.scala
@@ -26,5 +26,5 @@ class EphemeralQueriesMapDAO(opts: Map[String, String], subPath: Option[String] 
   val memoryMap = opts
   override lazy val config: Config = new DummyConfig(subPath)
 
-  def prefix:String = Try(config.getString(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
+  def prefix: String = Try(config.getString(PrefixStreamingCatalogsConfig) + "_") getOrElse ("")
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralQueriesTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralQueriesTypesafeDAO.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 class EphemeralQueriesTypesafeDAO(configuration: Config) extends EphemeralQueriesDAO {
 
-  def prefix:String = Try(configuration.getString(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
+  def prefix: String = Try(configuration.getString(PrefixStreamingCatalogsConfig) + "_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralQueriesTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralQueriesTypesafeDAO.scala
@@ -16,9 +16,14 @@
 package org.apache.spark.sql.crossdata.daos.impl
 
 import com.typesafe.config.Config
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
 import org.apache.spark.sql.crossdata.daos.EphemeralQueriesDAO
 
+import scala.util.Try
+
 class EphemeralQueriesTypesafeDAO(configuration: Config) extends EphemeralQueriesDAO {
+
+  def prefix:String = Try(configuration.getString(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableMapDAO.scala
@@ -15,10 +15,15 @@
  */
 package org.apache.spark.sql.crossdata.daos.impl
 
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
 import org.apache.spark.sql.crossdata.daos.{EphemeralTableMapDAO => EphTableMapDAO}
+
+import scala.util.Try
 
 class EphemeralTableMapDAO (opts: Map[String, Any], subPath: Option[String] = None)
   extends EphTableMapDAO{
+
+  def prefix:String = Try(config.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
 
   val memoryMap = opts
   override lazy val config: Config = new DummyConfig(subPath)

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableMapDAO.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 class EphemeralTableMapDAO (opts: Map[String, Any], subPath: Option[String] = None)
   extends EphTableMapDAO{
 
-  def prefix:String = Try(config.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
+  def prefix: String = Try(config.getString(PrefixPermantCatalogsConfig) + "_") getOrElse ("")
 
   val memoryMap = opts
   override lazy val config: Config = new DummyConfig(subPath)

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableStatusMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableStatusMapDAO.scala
@@ -25,5 +25,5 @@ class EphemeralTableStatusMapDAO (opts: Map[String, String], subPath: Option[Str
   val memoryMap = opts
   override lazy val config: Config = new DummyConfig(subPath)
 
-  def prefix:String = Try(config.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
+  def prefix: String = Try(config.getString(PrefixPermantCatalogsConfig) + "_") getOrElse ("")
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableStatusMapDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableStatusMapDAO.scala
@@ -15,10 +15,15 @@
  */
 package org.apache.spark.sql.crossdata.daos.impl
 
-import org.apache.spark.sql.crossdata.daos.{EphemeralTableStatusMapDAO => EphTableStatusMapDAO }
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
+import org.apache.spark.sql.crossdata.daos.{EphemeralTableStatusMapDAO => EphTableStatusMapDAO}
+
+import scala.util.Try
 class EphemeralTableStatusMapDAO (opts: Map[String, String], subPath: Option[String] = None)
   extends EphTableStatusMapDAO{
 
   val memoryMap = opts
   override lazy val config: Config = new DummyConfig(subPath)
+
+  def prefix:String = Try(config.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
 }

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableStatusTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableStatusTypesafeDAO.scala
@@ -16,9 +16,14 @@
 package org.apache.spark.sql.crossdata.daos.impl
 
 import com.typesafe.config.Config
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
 import org.apache.spark.sql.crossdata.daos.EphemeralTableStatusDAO
 
+import scala.util.Try
+
 class EphemeralTableStatusTypesafeDAO (configuration: Config) extends EphemeralTableStatusDAO {
+
+  def prefix:String = Try(configuration.getString(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableStatusTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableStatusTypesafeDAO.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 class EphemeralTableStatusTypesafeDAO (configuration: Config) extends EphemeralTableStatusDAO {
 
-  def prefix:String = Try(configuration.getString(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
+  def prefix: String = Try(configuration.getString(PrefixStreamingCatalogsConfig) + "_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableTypesafeDAO.scala
@@ -16,9 +16,14 @@
 package org.apache.spark.sql.crossdata.daos.impl
 
 import com.typesafe.config.Config
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
 import org.apache.spark.sql.crossdata.daos.EphemeralTableDAO
 
+import scala.util.Try
+
 class EphemeralTableTypesafeDAO(configuration: Config) extends EphemeralTableDAO {
+
+  def prefix:String = Try(configuration.getString(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/EphemeralTableTypesafeDAO.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 class EphemeralTableTypesafeDAO(configuration: Config) extends EphemeralTableDAO {
 
-  def prefix:String = Try(configuration.getString(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
+  def prefix: String = Try(configuration.getString(PrefixStreamingCatalogsConfig) + "_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/IndexTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/IndexTypesafeDAO.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 class IndexTypesafeDAO(configuration: Config) extends IndexDAO {
 
-  def prefix:String = Try(configuration.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
+  def prefix: String = Try(configuration.getString(PrefixPermantCatalogsConfig) + "_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/TableTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/TableTypesafeDAO.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 class TableTypesafeDAO(configuration: Config) extends TableDAO {
 
-  def prefix:String = Try(configuration.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
+  def prefix: String = Try(configuration.getString(PrefixPermantCatalogsConfig) + "_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/TableTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/TableTypesafeDAO.scala
@@ -17,8 +17,13 @@ package org.apache.spark.sql.crossdata.daos.impl
 
 import com.typesafe.config.Config
 import org.apache.spark.sql.crossdata.daos.TableDAO
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
+
+import scala.util.Try
 
 class TableTypesafeDAO(configuration: Config) extends TableDAO {
+
+  def prefix:String = Try(configuration.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/ViewTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/ViewTypesafeDAO.scala
@@ -16,9 +16,14 @@
 package org.apache.spark.sql.crossdata.daos.impl
 
 import com.typesafe.config.Config
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
 import org.apache.spark.sql.crossdata.daos.ViewDAO
 
+import scala.util.Try
+
 class ViewTypesafeDAO(configuration: Config) extends ViewDAO {
+
+  def prefix:String = Try(configuration.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/ViewTypesafeDAO.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/daos/impl/ViewTypesafeDAO.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 class ViewTypesafeDAO(configuration: Config) extends ViewDAO {
 
-  def prefix:String = Try(configuration.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
+  def prefix: String = Try(configuration.getString(PrefixPermantCatalogsConfig) + "_") getOrElse ("")
 
   override val config = new TypesafeConfig(Option(configuration))
 

--- a/core/src/test/resources/catalogspec/mysql-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/mysql-catalog-test-properties.conf
@@ -1,15 +1,13 @@
 ##########################################
 #                                        #
-#      Zookeeper Catalog Options         #
+#      MySQL Catalog Options         #
 #                                        #
 ##########################################
 
-#crossdata-core.catalog.
-
-class = "org.apache.spark.sql.crossdata.catalog.MySQLCatalog"
-jdbc.driver = "org.mariadb.jdbc.Driver"
-jdbc.url = "jdbc:mysql://127.0.0.1:3306/"
-jdbc.db.name = "crossdata"
-jdbc.db.user = "root"
-jdbc.db.pass = ""
-prefix = "crossdataClusterTest"
+crossdata-core.catalog.class = "org.apache.spark.sql.crossdata.catalog.MySQLCatalog"
+crossdata-core.catalog.jdbc.driver = "org.mariadb.jdbc.Driver"
+crossdata-core.catalog.jdbc.url = "jdbc:mysql://127.0.0.1:3306/"
+crossdata-core.catalog.jdbc.db.name = "crossdata"
+crossdata-core.catalog.jdbc.db.user = "root"
+crossdata-core.catalog.jdbc.db.pass = ""
+crossdata-core.catalog.prefix = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/mysql-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/mysql-catalog-test-properties.conf
@@ -4,10 +4,12 @@
 #                                        #
 ##########################################
 
+#crossdata-core.catalog.
 
-crossdata-core.catalog.zookeeper.connectionString = "localhost:2181"
-crossdata-core.catalog.zookeeper.connectionTimeout = 15000
-crossdata-core.catalog.zookeeper.sessionTimeout = 60000
-crossdata-core.catalog.zookeeper.retryAttempts = 5
-crossdata-core.catalog.zookeeper.retryInterval = 10000
-crossdata-core.catalog.clustername = "crossdataClusterTest"
+class = "org.apache.spark.sql.crossdata.catalog.MySQLCatalog"
+jdbc.driver = "org.mariadb.jdbc.Driver"
+jdbc.url = "jdbc:mysql://127.0.0.1:3306/"
+jdbc.db.name = "crossdata"
+jdbc.db.user = "root"
+jdbc.db.pass = ""
+prefix = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/mysql-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/mysql-catalog-test-properties.conf
@@ -1,0 +1,13 @@
+##########################################
+#                                        #
+#      Zookeeper Catalog Options         #
+#                                        #
+##########################################
+
+
+crossdata-core.catalog.zookeeper.connectionString = "localhost:2181"
+crossdata-core.catalog.zookeeper.connectionTimeout = 15000
+crossdata-core.catalog.zookeeper.sessionTimeout = 60000
+crossdata-core.catalog.zookeeper.retryAttempts = 5
+crossdata-core.catalog.zookeeper.retryInterval = 10000
+crossdata-core.catalog.clustername = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/postgresql-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/postgresql-catalog-test-properties.conf
@@ -4,10 +4,11 @@
 #                                        #
 ##########################################
 
+#crossdata-core.catalog.
 
-crossdata-core.catalog.zookeeper.connectionString = "localhost:2181"
-crossdata-core.catalog.zookeeper.connectionTimeout = 15000
-crossdata-core.catalog.zookeeper.sessionTimeout = 60000
-crossdata-core.catalog.zookeeper.retryAttempts = 5
-crossdata-core.catalog.zookeeper.retryInterval = 10000
-crossdata-core.catalog.clustername = "crossdataPostgresClusterTest"
+class = "org.apache.spark.sql.crossdata.catalog.PostgreSQLCatalog"
+jdbc.driver = "org.postgresql.Driver"
+jdbc.url = "jdbc:postgresql://127.0.0.1:5432/"
+jdbc.db.user = "postgres"
+jdbc.db.pass = "postgres"
+prefix = "crossdataPostgresClusterTest"

--- a/core/src/test/resources/catalogspec/postgresql-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/postgresql-catalog-test-properties.conf
@@ -1,14 +1,13 @@
 ##########################################
 #                                        #
-#      Zookeeper Catalog Options         #
+#      PostgreSQL Catalog Options         #
 #                                        #
 ##########################################
 
-#crossdata-core.catalog.
 
-class = "org.apache.spark.sql.crossdata.catalog.PostgreSQLCatalog"
-jdbc.driver = "org.postgresql.Driver"
-jdbc.url = "jdbc:postgresql://127.0.0.1:5432/"
-jdbc.db.user = "postgres"
-jdbc.db.pass = "postgres"
-prefix = "crossdataPostgresClusterTest"
+crossdata-core.catalog.class = "org.apache.spark.sql.crossdata.catalog.PostgreSQLCatalog"
+crossdata-core.catalog.jdbc.driver = "org.postgresql.Driver"
+crossdata-core.catalog.jdbc.url = "jdbc:postgresql://127.0.0.1:5432/"
+crossdata-core.catalog.jdbc.db.user = "postgres"
+crossdata-core.catalog.jdbc.db.pass = "postgres"
+crossdata-core.catalog.prefix = "crossdataPostgresClusterTest"

--- a/core/src/test/resources/catalogspec/postgresql-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/postgresql-catalog-test-properties.conf
@@ -1,0 +1,12 @@
+##########################################
+#                                        #
+#      Zookeeper Catalog Options         #
+#                                        #
+##########################################
+
+
+crossdata-core.catalog.zookeeper.connectionString = "localhost:2181"
+crossdata-core.catalog.zookeeper.connectionTimeout = 15000
+crossdata-core.catalog.zookeeper.sessionTimeout = 60000
+crossdata-core.catalog.zookeeper.retryAttempts = 5
+crossdata-core.catalog.zookeeper.retryInterval = 10000

--- a/core/src/test/resources/catalogspec/postgresql-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/postgresql-catalog-test-properties.conf
@@ -10,3 +10,4 @@ crossdata-core.catalog.zookeeper.connectionTimeout = 15000
 crossdata-core.catalog.zookeeper.sessionTimeout = 60000
 crossdata-core.catalog.zookeeper.retryAttempts = 5
 crossdata-core.catalog.zookeeper.retryInterval = 10000
+crossdata-core.catalog.clustername = "crossdataPostgresClusterTest"

--- a/core/src/test/resources/catalogspec/zookeeper-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/zookeeper-catalog-test-properties.conf
@@ -11,4 +11,4 @@ crossdata-core.catalog.zookeeper.connectionTimeout = 15000
 crossdata-core.catalog.zookeeper.sessionTimeout = 60000
 crossdata-core.catalog.zookeeper.retryAttempts = 5
 crossdata-core.catalog.zookeeper.retryInterval = 10000
-crossdata-core.catalog.zookeeper.prefix = "crossdataClusterTest"
+crossdata-core.catalog.prefix = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/zookeeper-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/zookeeper-catalog-test-properties.conf
@@ -11,4 +11,4 @@ crossdata-core.catalog.zookeeper.connectionTimeout = 15000
 crossdata-core.catalog.zookeeper.sessionTimeout = 60000
 crossdata-core.catalog.zookeeper.retryAttempts = 5
 crossdata-core.catalog.zookeeper.retryInterval = 10000
-crossdata-core.catalog.prefix = "crossdataClusterTest"
+crossdata-core.catalog.zookeeper.prefix = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/zookeeper-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/zookeeper-catalog-test-properties.conf
@@ -5,11 +5,10 @@
 ##########################################
 
 
-#crossdata-core.catalog.
-class = "org.apache.spark.sql.crossdata.catalog.ZookeeperCatalog"
-zookeeper.connectionString = "localhost:2181"
-zookeeper.connectionTimeout = 15000
-zookeeper.sessionTimeout = 60000
-zookeeper.retryAttempts = 5
-zookeeper.retryInterval = 10000
-prefix = "crossdataClusterTest"
+crossdata-core.catalog.class = "org.apache.spark.sql.crossdata.catalog.ZookeeperCatalog"
+crossdata-core.catalog.zookeeper.connectionString = "localhost:2181"
+crossdata-core.catalog.zookeeper.connectionTimeout = 15000
+crossdata-core.catalog.zookeeper.sessionTimeout = 60000
+crossdata-core.catalog.zookeeper.retryAttempts = 5
+crossdata-core.catalog.zookeeper.retryInterval = 10000
+crossdata-core.catalog.prefix = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/zookeeper-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/zookeeper-catalog-test-properties.conf
@@ -5,9 +5,11 @@
 ##########################################
 
 
-crossdata-core.catalog.zookeeper.connectionString = "localhost:2181"
-crossdata-core.catalog.zookeeper.connectionTimeout = 15000
-crossdata-core.catalog.zookeeper.sessionTimeout = 60000
-crossdata-core.catalog.zookeeper.retryAttempts = 5
-crossdata-core.catalog.zookeeper.retryInterval = 10000
-crossdata-core.catalog.clustername = "crossdataClusterTest"
+#crossdata-core.catalog.
+class = "org.apache.spark.sql.crossdata.catalog.ZookeeperCatalog"
+zookeeper.connectionString = "localhost:2181"
+zookeeper.connectionTimeout = 15000
+zookeeper.sessionTimeout = 60000
+zookeeper.retryAttempts = 5
+zookeeper.retryInterval = 10000
+prefix = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/zookeeper-catalog-test-properties.conf
+++ b/core/src/test/resources/catalogspec/zookeeper-catalog-test-properties.conf
@@ -1,0 +1,13 @@
+##########################################
+#                                        #
+#      Zookeeper Catalog Options         #
+#                                        #
+##########################################
+
+
+crossdata-core.catalog.zookeeper.connectionString = "localhost:2181"
+crossdata-core.catalog.zookeeper.connectionTimeout = 15000
+crossdata-core.catalog.zookeeper.sessionTimeout = 60000
+crossdata-core.catalog.zookeeper.retryAttempts = 5
+crossdata-core.catalog.zookeeper.retryInterval = 10000
+crossdata-core.catalog.clustername = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/zookeeper-streaming-catalog-with-prefix.conf
+++ b/core/src/test/resources/catalogspec/zookeeper-streaming-catalog-with-prefix.conf
@@ -10,4 +10,4 @@ crossdata-core.streaming.catalog.zookeeper.connectionTimeout = 15000
 crossdata-core.streaming.catalog.zookeeper.sessionTimeout = 60000
 crossdata-core.streaming.catalog.zookeeper.retryAttempts = 5
 crossdata-core.streaming.catalog.zookeeper.retryInterval = 10000
-crossdata-core.streaming.catalog.prefix = "crossdataClusterTest"
+crossdata-core.streaming.catalog.zookeeper.prefix = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/zookeeper-streaming-catalog-with-prefix.conf
+++ b/core/src/test/resources/catalogspec/zookeeper-streaming-catalog-with-prefix.conf
@@ -1,0 +1,15 @@
+##########################################
+#                                        #
+#      Zookeeper Catalog Options         #
+#                                        #
+##########################################
+
+#crossdata-core.
+
+streaming.catalog.class= "org.apache.spark.sql.crossdata.catalog.streaming.ZookeeperStreamingCatalog"
+streaming.catalog.zookeeper.connectionString = "localhost:2181"
+streaming.catalog.zookeeper.connectionTimeout = 15000
+streaming.catalog.zookeeper.sessionTimeout = 60000
+streaming.catalog.zookeeper.retryAttempts = 5
+streaming.catalog.zookeeper.retryInterval = 10000
+streaming.catalog.prefix = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/zookeeper-streaming-catalog-with-prefix.conf
+++ b/core/src/test/resources/catalogspec/zookeeper-streaming-catalog-with-prefix.conf
@@ -4,12 +4,10 @@
 #                                        #
 ##########################################
 
-#crossdata-core.
-
-streaming.catalog.class= "org.apache.spark.sql.crossdata.catalog.streaming.ZookeeperStreamingCatalog"
-streaming.catalog.zookeeper.connectionString = "localhost:2181"
-streaming.catalog.zookeeper.connectionTimeout = 15000
-streaming.catalog.zookeeper.sessionTimeout = 60000
-streaming.catalog.zookeeper.retryAttempts = 5
-streaming.catalog.zookeeper.retryInterval = 10000
-streaming.catalog.prefix = "crossdataClusterTest"
+crossdata-core.streaming.catalog.class= "org.apache.spark.sql.crossdata.catalog.streaming.ZookeeperStreamingCatalog"
+crossdata-core.streaming.catalog.zookeeper.connectionString = "localhost:2181"
+crossdata-core.streaming.catalog.zookeeper.connectionTimeout = 15000
+crossdata-core.streaming.catalog.zookeeper.sessionTimeout = 60000
+crossdata-core.streaming.catalog.zookeeper.retryAttempts = 5
+crossdata-core.streaming.catalog.zookeeper.retryInterval = 10000
+crossdata-core.streaming.catalog.prefix = "crossdataClusterTest"

--- a/core/src/test/resources/catalogspec/zookeeper-streaming-catalog-without-prefix.conf
+++ b/core/src/test/resources/catalogspec/zookeeper-streaming-catalog-without-prefix.conf
@@ -1,0 +1,14 @@
+##########################################
+#                                        #
+#      Zookeeper Catalog Options         #
+#                                        #
+##########################################
+
+#crossdata-core.
+
+streaming.catalog.class= "org.apache.spark.sql.crossdata.catalog.streaming.ZookeeperStreamingCatalog"
+streaming.catalog.zookeeper.connectionString = "localhost:2181"
+streaming.catalog.zookeeper.connectionTimeout = 15000
+streaming.catalog.zookeeper.sessionTimeout = 60000
+streaming.catalog.zookeeper.retryAttempts = 5
+streaming.catalog.zookeeper.retryInterval = 10000

--- a/core/src/test/resources/catalogspec/zookeeper-streaming-catalog-without-prefix.conf
+++ b/core/src/test/resources/catalogspec/zookeeper-streaming-catalog-without-prefix.conf
@@ -4,11 +4,9 @@
 #                                        #
 ##########################################
 
-#crossdata-core.
-
-streaming.catalog.class= "org.apache.spark.sql.crossdata.catalog.streaming.ZookeeperStreamingCatalog"
-streaming.catalog.zookeeper.connectionString = "localhost:2181"
-streaming.catalog.zookeeper.connectionTimeout = 15000
-streaming.catalog.zookeeper.sessionTimeout = 60000
-streaming.catalog.zookeeper.retryAttempts = 5
-streaming.catalog.zookeeper.retryInterval = 10000
+crossdata-core.streaming.catalog.class= "org.apache.spark.sql.crossdata.catalog.streaming.ZookeeperStreamingCatalog"
+crossdata-core.streaming.catalog.zookeeper.connectionString = "localhost:2181"
+crossdata-core.streaming.catalog.zookeeper.connectionTimeout = 15000
+crossdata-core.streaming.catalog.zookeeper.sessionTimeout = 60000
+crossdata-core.streaming.catalog.zookeeper.retryAttempts = 5
+crossdata-core.streaming.catalog.zookeeper.retryInterval = 10000

--- a/core/src/test/resources/core-reference.conf
+++ b/core/src/test/resources/core-reference.conf
@@ -53,7 +53,7 @@ crossdata-core.streaming.catalog.zookeeper.connectionTimeout = 15000
 crossdata-core.streaming.catalog.zookeeper.sessionTimeout = 60000
 crossdata-core.streaming.catalog.zookeeper.retryAttempts = 5
 crossdata-core.streaming.catalog.zookeeper.retryInterval = 10000
-//crossdata-core.streaming.catalog.prefix = "crossdataCluster"
+//crossdata-core.streaming.catalog.zookeeper.prefix = "crossdataCluster"
 
 
 

--- a/core/src/test/resources/core-reference.conf
+++ b/core/src/test/resources/core-reference.conf
@@ -53,7 +53,7 @@ crossdata-core.streaming.catalog.zookeeper.connectionTimeout = 15000
 crossdata-core.streaming.catalog.zookeeper.sessionTimeout = 60000
 crossdata-core.streaming.catalog.zookeeper.retryAttempts = 5
 crossdata-core.streaming.catalog.zookeeper.retryInterval = 10000
-//crossdata-core.streaming.catalog.zookeeper.prefix = "crossdataCluster"
+crossdata-core.streaming.catalog.zookeeper.prefix = "crossdataCluster"
 
 
 

--- a/core/src/test/resources/core-reference.conf
+++ b/core/src/test/resources/core-reference.conf
@@ -18,7 +18,7 @@ crossdata-core.external.config.filename = ${?crossdata_core_external_config_file
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
 #crossdata-core.catalog.jdbc.db.user = "root"
 #crossdata-core.catalog.jdbc.db.pass = ""
-#crossdata-core.catalog.clustername = "crossdataCluster"
+#crossdata-core.catalog.prefix = "crossdataCluster"
 
 
 ####### PostgreSQL ###########
@@ -27,7 +27,7 @@ crossdata-core.external.config.filename = ${?crossdata_core_external_config_file
 #crossdata-core.catalog.jdbc.url = "jdbc:postgresql://127.0.0.1:5432/"
 #crossdata-core.catalog.jdbc.db.user = "postgres"
 #crossdata-core.catalog.jdbc.db.pass = "postgres"
-#crossdata-core.catalog.clustername = "crossdataCluster"
+#crossdata-core.catalog.prefix = "crossdataCluster"
 
 ####### Zookeeper Catalog Configuration ###########
 #crossdata-core.catalog.class = "org.apache.spark.sql.crossdata.catalog.ZookeeperCatalog"
@@ -36,7 +36,7 @@ crossdata-core.external.config.filename = ${?crossdata_core_external_config_file
 #crossdata-core.catalog.zookeeper.sessionTimeout = 60000
 #crossdata-core.catalog.zookeeper.retryAttempts = 5
 #crossdata-core.catalog.zookeeper.retryInterval = 10000
-#crossdata-core.catalog.clustername = "crossdataCluster"
+#crossdata-core.catalog.prefix = "crossdataCluster"
 
 
 
@@ -53,6 +53,7 @@ crossdata-core.streaming.catalog.zookeeper.connectionTimeout = 15000
 crossdata-core.streaming.catalog.zookeeper.sessionTimeout = 60000
 crossdata-core.streaming.catalog.zookeeper.retryAttempts = 5
 crossdata-core.streaming.catalog.zookeeper.retryInterval = 10000
+//crossdata-core.streaming.catalog.prefix = "crossdataCluster"
 
 
 

--- a/core/src/test/resources/core-reference.conf
+++ b/core/src/test/resources/core-reference.conf
@@ -16,20 +16,18 @@ crossdata-core.external.config.filename = ${?crossdata_core_external_config_file
 #crossdata-core.catalog.jdbc.driver = "org.mariadb.jdbc.Driver"
 #crossdata-core.catalog.jdbc.url = "jdbc:mysql://127.0.0.1:3306/"
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
-#crossdata-core.catalog.jdbc.db.table = "crossdataTables"
-#crossdata-core.catalog.jdbc.db.view = "crossdataViews"
 #crossdata-core.catalog.jdbc.db.user = "root"
 #crossdata-core.catalog.jdbc.db.pass = ""
+#crossdata-core.catalog.clustername = "crossdataCluster"
 
 
 ####### PostgreSQL ###########
 #crossdata-core.catalog.class = "org.apache.spark.sql.crossdata.catalog.PostgreSQLCatalog"
 #crossdata-core.catalog.jdbc.driver = "org.postgresql.Driver"
 #crossdata-core.catalog.jdbc.url = "jdbc:postgresql://127.0.0.1:5432/"
-#crossdata-core.catalog.jdbc.db.name = "crossdata"
-#crossdata-core.catalog.jdbc.db.table = "crossdataTables"
 #crossdata-core.catalog.jdbc.db.user = "postgres"
 #crossdata-core.catalog.jdbc.db.pass = "postgres"
+#crossdata-core.catalog.clustername = "crossdataCluster"
 
 ####### Zookeeper Catalog Configuration ###########
 #crossdata-core.catalog.class = "org.apache.spark.sql.crossdata.catalog.ZookeeperCatalog"
@@ -38,6 +36,7 @@ crossdata-core.external.config.filename = ${?crossdata_core_external_config_file
 #crossdata-core.catalog.zookeeper.sessionTimeout = 60000
 #crossdata-core.catalog.zookeeper.retryAttempts = 5
 #crossdata-core.catalog.zookeeper.retryInterval = 10000
+#crossdata-core.catalog.clustername = "crossdataCluster"
 
 
 

--- a/core/src/test/resources/zookeeper-catalog.conf
+++ b/core/src/test/resources/zookeeper-catalog.conf
@@ -10,3 +10,4 @@ crossdata-core.catalog.zookeeper.connectionTimeout = 15000
 crossdata-core.catalog.zookeeper.sessionTimeout = 60000
 crossdata-core.catalog.zookeeper.retryAttempts = 5
 crossdata-core.catalog.zookeeper.retryInterval = 10000
+crossdata-core.catalog.prefix = "crossdataCluster"

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLCatalogSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.crossdata.catalog.persistent
+
+import com.stratio.crossdata.test.BaseXDTest
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.spark.sql.catalyst.{CatalystConf, SimpleCatalystConf}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class MySQLCatalogSpec extends BaseXDTest {
+
+  private class MySQLCatalogWithMockedConfig(override val catalystConf: CatalystConf) extends MySQLXDCatalog(catalystConf) {
+    override lazy val config: Config = ConfigFactory.load("catalogspec/mysql-catalog-test-properties.conf")
+  }
+
+  it should "get the cluster name from the config if specified" in {
+    val catalog = new MySQLCatalogWithMockedConfig(new SimpleCatalystConf(true))
+    catalog.config.getString("crossdata-core.catalog.clustername") shouldBe "crossdataClusterTest"
+    catalog.tablesPrefix shouldBe "crossdataClusterTest_"
+    catalog.tableWithTableMetadata shouldBe "crossdataClusterTest_crossdataTables"
+    catalog.tableWithViewMetadata shouldBe "crossdataClusterTest_crossdataViews"
+    catalog.tableWithAppJars shouldBe "crossdataClusterTest_crossdataJars"
+    catalog.tableWithIndexMetadata shouldBe "crossdataClusterTest_crossdataIndexes"
+  }
+
+  it should "work with the default values if cluster name is not specified" in {
+    val catalog = new MySQLXDCatalog(new SimpleCatalystConf(true))
+    an[Exception] shouldBe thrownBy(catalog.config.getString("crossdata-core.catalog.clustername"))
+    catalog.tablesPrefix shouldBe ""
+    catalog.tableWithTableMetadata shouldBe "crossdataTables"
+    catalog.tableWithViewMetadata shouldBe "crossdataViews"
+    catalog.tableWithAppJars shouldBe "crossdataJars"
+    catalog.tableWithIndexMetadata shouldBe "crossdataIndexes"
+  }
+
+}

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLCatalogSpec.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.crossdata.catalog.persistent
 import com.stratio.crossdata.test.BaseXDTest
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.sql.catalyst.{CatalystConf, SimpleCatalystConf}
+import org.apache.spark.sql.crossdata.config.CoreConfig
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -26,16 +27,17 @@ import org.scalatest.junit.JUnitRunner
 class MySQLCatalogSpec extends BaseXDTest {
 
   private class MySQLCatalogPublicMetadata(override val catalystConf: CatalystConf) extends MySQLXDCatalog(catalystConf){
-    def tablesPrefixTest = tablesPrefix
-    def tableWithTableMetadataTest = tableWithTableMetadata
-    def tableWithViewMetadataTest = tableWithViewMetadata
-    def tableWithAppJarsTest = tableWithAppJars
-    def tableWithIndexMetadataTest = tableWithIndexMetadata
-    def configTest = config
+    val tablesPrefixTest = tablesPrefix
+    val tableWithTableMetadataTest = tableWithTableMetadata
+    val tableWithViewMetadataTest = tableWithViewMetadata
+    val tableWithAppJarsTest = tableWithAppJars
+    val tableWithIndexMetadataTest = tableWithIndexMetadata
+    val configTest = config
   }
 
   private class MySQLCatalogWithMockedConfig(override val catalystConf: CatalystConf) extends MySQLCatalogPublicMetadata(catalystConf) {
-    override lazy val config: Config = ConfigFactory.load("catalogspec/mysql-catalog-test-properties.conf")
+    override lazy val config: Config =
+      ConfigFactory.load("catalogspec/mysql-catalog-test-properties.conf").getConfig(Seq(CoreConfig.ParentConfigName, CoreConfig.CatalogConfigKey) mkString ".")
   }
 
   it should "get the cluster name from the config if specified" in {

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLCatalogSpec.scala
@@ -25,28 +25,37 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class MySQLCatalogSpec extends BaseXDTest {
 
-  private class MySQLCatalogWithMockedConfig(override val catalystConf: CatalystConf) extends MySQLXDCatalog(catalystConf) {
+  private class MySQLCatalogPublicMetadata(override val catalystConf: CatalystConf) extends MySQLXDCatalog(catalystConf){
+    def tablesPrefixTest = tablesPrefix
+    def tableWithTableMetadataTest = tableWithTableMetadata
+    def tableWithViewMetadataTest = tableWithViewMetadata
+    def tableWithAppJarsTest = tableWithAppJars
+    def tableWithIndexMetadataTest = tableWithIndexMetadata
+    def configTest = config
+  }
+
+  private class MySQLCatalogWithMockedConfig(override val catalystConf: CatalystConf) extends MySQLCatalogPublicMetadata(catalystConf) {
     override lazy val config: Config = ConfigFactory.load("catalogspec/mysql-catalog-test-properties.conf")
   }
 
   it should "get the cluster name from the config if specified" in {
     val catalog = new MySQLCatalogWithMockedConfig(new SimpleCatalystConf(true))
-    catalog.config.getString("crossdata-core.catalog.clustername") shouldBe "crossdataClusterTest"
-    catalog.tablesPrefix shouldBe "crossdataClusterTest_"
-    catalog.tableWithTableMetadata shouldBe "crossdataClusterTest_crossdataTables"
-    catalog.tableWithViewMetadata shouldBe "crossdataClusterTest_crossdataViews"
-    catalog.tableWithAppJars shouldBe "crossdataClusterTest_crossdataJars"
-    catalog.tableWithIndexMetadata shouldBe "crossdataClusterTest_crossdataIndexes"
+    catalog.configTest.getString("crossdata-core.catalog.clustername") shouldBe "crossdataClusterTest"
+    catalog.tablesPrefixTest shouldBe "crossdataClusterTest_"
+    catalog.tableWithTableMetadataTest shouldBe "crossdataClusterTest_crossdataTables"
+    catalog.tableWithViewMetadataTest shouldBe "crossdataClusterTest_crossdataViews"
+    catalog.tableWithAppJarsTest shouldBe "crossdataClusterTest_crossdataJars"
+    catalog.tableWithIndexMetadataTest shouldBe "crossdataClusterTest_crossdataIndexes"
   }
 
   it should "work with the default values if cluster name is not specified" in {
-    val catalog = new MySQLXDCatalog(new SimpleCatalystConf(true))
-    an[Exception] shouldBe thrownBy(catalog.config.getString("crossdata-core.catalog.clustername"))
-    catalog.tablesPrefix shouldBe ""
-    catalog.tableWithTableMetadata shouldBe "crossdataTables"
-    catalog.tableWithViewMetadata shouldBe "crossdataViews"
-    catalog.tableWithAppJars shouldBe "crossdataJars"
-    catalog.tableWithIndexMetadata shouldBe "crossdataIndexes"
+    val catalog = new MySQLCatalogPublicMetadata(new SimpleCatalystConf(true))
+    an[Exception] shouldBe thrownBy(catalog.configTest.getString("crossdata-core.catalog.clustername"))
+    catalog.tablesPrefixTest shouldBe ""
+    catalog.tableWithTableMetadataTest shouldBe "crossdataTables"
+    catalog.tableWithViewMetadataTest shouldBe "crossdataViews"
+    catalog.tableWithAppJarsTest shouldBe "crossdataJars"
+    catalog.tableWithIndexMetadataTest shouldBe "crossdataIndexes"
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/MySQLCatalogSpec.scala
@@ -40,7 +40,7 @@ class MySQLCatalogSpec extends BaseXDTest {
 
   it should "get the cluster name from the config if specified" in {
     val catalog = new MySQLCatalogWithMockedConfig(new SimpleCatalystConf(true))
-    catalog.configTest.getString("crossdata-core.catalog.clustername") shouldBe "crossdataClusterTest"
+    catalog.configTest.getString("prefix") shouldBe "crossdataClusterTest"
     catalog.tablesPrefixTest shouldBe "crossdataClusterTest_"
     catalog.tableWithTableMetadataTest shouldBe "crossdataClusterTest_crossdataTables"
     catalog.tableWithViewMetadataTest shouldBe "crossdataClusterTest_crossdataViews"
@@ -50,7 +50,7 @@ class MySQLCatalogSpec extends BaseXDTest {
 
   it should "work with the default values if cluster name is not specified" in {
     val catalog = new MySQLCatalogPublicMetadata(new SimpleCatalystConf(true))
-    an[Exception] shouldBe thrownBy(catalog.configTest.getString("crossdata-core.catalog.clustername"))
+    an[Exception] shouldBe thrownBy(catalog.configTest.getString("prefix"))
     catalog.tablesPrefixTest shouldBe ""
     catalog.tableWithTableMetadataTest shouldBe "crossdataTables"
     catalog.tableWithViewMetadataTest shouldBe "crossdataViews"

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLCatalogSpec.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.crossdata.catalog.persistent
 import com.stratio.crossdata.test.BaseXDTest
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.sql.catalyst.{CatalystConf, SimpleCatalystConf}
+import org.apache.spark.sql.crossdata.config.CoreConfig
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -26,16 +27,17 @@ import org.scalatest.junit.JUnitRunner
 class PostgreSQLCatalogSpec extends BaseXDTest {
 
   private class PostgreSQLCatalogPublicMetadata(override val catalystConf: CatalystConf) extends PostgreSQLXDCatalog(catalystConf){
-    def tablesPrefixTest = tablesPrefix
-    def tableWithTableMetadataTest = tableWithTableMetadata
-    def tableWithViewMetadataTest = tableWithViewMetadata
-    def tableWithAppJarsTest = tableWithAppJars
-    def tableWithIndexMetadataTest = tableWithIndexMetadata
-    def configTest = config
+    val tablesPrefixTest = tablesPrefix
+    val tableWithTableMetadataTest = tableWithTableMetadata
+    val tableWithViewMetadataTest = tableWithViewMetadata
+    val tableWithAppJarsTest = tableWithAppJars
+    val tableWithIndexMetadataTest = tableWithIndexMetadata
+    val configTest = config
   }
 
   private class PostgreSQLCatalogWithMockedConfig(override val catalystConf: CatalystConf) extends PostgreSQLCatalogPublicMetadata(catalystConf) {
-    override lazy val config: Config = ConfigFactory.load("catalogspec/postgresql-catalog-test-properties.conf")
+    override lazy val config: Config =
+      ConfigFactory.load("catalogspec/postgresql-catalog-test-properties.conf").getConfig(Seq(CoreConfig.ParentConfigName, CoreConfig.CatalogConfigKey) mkString ".")
   }
 
   it should "get the cluster name from the config if specified" in {

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLCatalogSpec.scala
@@ -40,7 +40,7 @@ class PostgreSQLCatalogSpec extends BaseXDTest {
 
   it should "get the cluster name from the config if specified" in {
     val catalog = new PostgreSQLCatalogWithMockedConfig(new SimpleCatalystConf(true))
-    catalog.configTest.getString("crossdata-core.catalog.clustername") shouldBe "crossdataPostgresClusterTest"
+    catalog.configTest.getString("prefix") shouldBe "crossdataPostgresClusterTest"
     catalog.tablesPrefixTest shouldBe "crossdataPostgresClusterTest_"
     catalog.tableWithTableMetadataTest shouldBe "crossdataPostgresClusterTest_crossdataTables"
     catalog.tableWithViewMetadataTest shouldBe "crossdataPostgresClusterTest_crossdataViews"
@@ -50,7 +50,7 @@ class PostgreSQLCatalogSpec extends BaseXDTest {
 
   it should "work with the default values if cluster name is not specified" in {
     val catalog = new PostgreSQLCatalogPublicMetadata(new SimpleCatalystConf(true))
-    an[Exception] shouldBe thrownBy(catalog.configTest.getString("crossdata-core.catalog.clustername"))
+    an[Exception] shouldBe thrownBy(catalog.configTest.getString("prefix"))
     catalog.tablesPrefixTest shouldBe ""
     catalog.tableWithTableMetadataTest shouldBe "crossdataTables"
     catalog.tableWithViewMetadataTest shouldBe "crossdataViews"

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLCatalogSpec.scala
@@ -25,28 +25,37 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class PostgreSQLCatalogSpec extends BaseXDTest {
 
-  private class PostgreSQLCatalogWithMockedConfig(override val catalystConf: CatalystConf) extends PostgreSQLXDCatalog(catalystConf) {
+  private class PostgreSQLCatalogPublicMetadata(override val catalystConf: CatalystConf) extends PostgreSQLXDCatalog(catalystConf){
+    def tablesPrefixTest = tablesPrefix
+    def tableWithTableMetadataTest = tableWithTableMetadata
+    def tableWithViewMetadataTest = tableWithViewMetadata
+    def tableWithAppJarsTest = tableWithAppJars
+    def tableWithIndexMetadataTest = tableWithIndexMetadata
+    def configTest = config
+  }
+
+  private class PostgreSQLCatalogWithMockedConfig(override val catalystConf: CatalystConf) extends PostgreSQLCatalogPublicMetadata(catalystConf) {
     override lazy val config: Config = ConfigFactory.load("catalogspec/postgresql-catalog-test-properties.conf")
   }
 
   it should "get the cluster name from the config if specified" in {
     val catalog = new PostgreSQLCatalogWithMockedConfig(new SimpleCatalystConf(true))
-    catalog.config.getString("crossdata-core.catalog.clustername") shouldBe "crossdataPostgresClusterTest"
-    catalog.tablesPrefix shouldBe "crossdataPostgresClusterTest_"
-    catalog.tableWithTableMetadata shouldBe "crossdataPostgresClusterTest_crossdataTables"
-    catalog.tableWithViewMetadata shouldBe "crossdataPostgresClusterTest_crossdataViews"
-    catalog.tableWithAppJars shouldBe "crossdataPostgresClusterTest_crossdataJars"
-    catalog.tableWithIndexMetadata shouldBe "crossdataPostgresClusterTest_crossdataIndexes"
+    catalog.configTest.getString("crossdata-core.catalog.clustername") shouldBe "crossdataPostgresClusterTest"
+    catalog.tablesPrefixTest shouldBe "crossdataPostgresClusterTest_"
+    catalog.tableWithTableMetadataTest shouldBe "crossdataPostgresClusterTest_crossdataTables"
+    catalog.tableWithViewMetadataTest shouldBe "crossdataPostgresClusterTest_crossdataViews"
+    catalog.tableWithAppJarsTest shouldBe "crossdataPostgresClusterTest_crossdataJars"
+    catalog.tableWithIndexMetadataTest shouldBe "crossdataPostgresClusterTest_crossdataIndexes"
   }
 
   it should "work with the default values if cluster name is not specified" in {
-    val catalog = new PostgreSQLXDCatalog(new SimpleCatalystConf(true))
-    an[Exception] shouldBe thrownBy(catalog.config.getString("crossdata-core.catalog.clustername"))
-    catalog.tablesPrefix shouldBe ""
-    catalog.tableWithTableMetadata shouldBe "crossdataTables"
-    catalog.tableWithViewMetadata shouldBe "crossdataViews"
-    catalog.tableWithAppJars shouldBe "crossdataJars"
-    catalog.tableWithIndexMetadata shouldBe "crossdataIndexes"
+    val catalog = new PostgreSQLCatalogPublicMetadata(new SimpleCatalystConf(true))
+    an[Exception] shouldBe thrownBy(catalog.configTest.getString("crossdata-core.catalog.clustername"))
+    catalog.tablesPrefixTest shouldBe ""
+    catalog.tableWithTableMetadataTest shouldBe "crossdataTables"
+    catalog.tableWithViewMetadataTest shouldBe "crossdataViews"
+    catalog.tableWithAppJarsTest shouldBe "crossdataJars"
+    catalog.tableWithIndexMetadataTest shouldBe "crossdataIndexes"
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/PostgreSQLCatalogSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.crossdata.catalog.persistent
+
+import com.stratio.crossdata.test.BaseXDTest
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.spark.sql.catalyst.{CatalystConf, SimpleCatalystConf}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class PostgreSQLCatalogSpec extends BaseXDTest {
+
+  private class PostgreSQLCatalogWithMockedConfig(override val catalystConf: CatalystConf) extends PostgreSQLXDCatalog(catalystConf) {
+    override lazy val config: Config = ConfigFactory.load("catalogspec/postgresql-catalog-test-properties.conf")
+  }
+
+  it should "get the cluster name from the config if specified" in {
+    val catalog = new PostgreSQLCatalogWithMockedConfig(new SimpleCatalystConf(true))
+    catalog.config.getString("crossdata-core.catalog.clustername") shouldBe "crossdataPostgresClusterTest"
+    catalog.tablesPrefix shouldBe "crossdataPostgresClusterTest_"
+    catalog.tableWithTableMetadata shouldBe "crossdataPostgresClusterTest_crossdataTables"
+    catalog.tableWithViewMetadata shouldBe "crossdataPostgresClusterTest_crossdataViews"
+    catalog.tableWithAppJars shouldBe "crossdataPostgresClusterTest_crossdataJars"
+    catalog.tableWithIndexMetadata shouldBe "crossdataPostgresClusterTest_crossdataIndexes"
+  }
+
+  it should "work with the default values if cluster name is not specified" in {
+    val catalog = new PostgreSQLXDCatalog(new SimpleCatalystConf(true))
+    an[Exception] shouldBe thrownBy(catalog.config.getString("crossdata-core.catalog.clustername"))
+    catalog.tablesPrefix shouldBe ""
+    catalog.tableWithTableMetadata shouldBe "crossdataTables"
+    catalog.tableWithViewMetadata shouldBe "crossdataViews"
+    catalog.tableWithAppJars shouldBe "crossdataJars"
+    catalog.tableWithIndexMetadata shouldBe "crossdataIndexes"
+  }
+
+}

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/ZookeeperCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/ZookeeperCatalogSpec.scala
@@ -35,10 +35,10 @@ class ZookeeperCatalogSpec extends BaseXDTest {
   it should "get the cluster name from the config" in {
     val catalog = new ZookeeperCatalogWithMockedConfig(new SimpleCatalystConf(true))
     catalog.config.getString("prefix") shouldBe "crossdataClusterTest"
-    catalog.tableDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/tables"
-    catalog.viewDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/views"
-    catalog.appDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/apps"
-    catalog.indexDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/indexes"
+    catalog.tableDAO.dao.entity shouldBe "stratio/crossdata/crossdataClusterTest_tables"
+    catalog.viewDAO.dao.entity shouldBe "stratio/crossdata/crossdataClusterTest_views"
+    catalog.appDAO.dao.entity shouldBe "stratio/crossdata/crossdataClusterTest_apps"
+    catalog.indexDAO.dao.entity shouldBe "stratio/crossdata/crossdataClusterTest_indexes"
 
     //Ephemeral
     val streamingCatalog = new ZookeeperStreamingCatalog(
@@ -46,9 +46,9 @@ class ZookeeperCatalogSpec extends BaseXDTest {
       ConfigFactory.load("catalogspec/zookeeper-streaming-catalog-with-prefix.conf").getConfig(CoreConfig.ParentConfigName)
     )
     streamingCatalog.streamingConfig.getString("catalog.zookeeper.prefix") shouldBe "crossdataClusterTest"
-    streamingCatalog.ephemeralQueriesDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/ephemeralqueries"
-    streamingCatalog.ephemeralTableDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/ephemeraltables"
-    streamingCatalog.ephemeralTableStatusDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/ephemeraltablestatus"
+    streamingCatalog.ephemeralQueriesDAO.dao.entity shouldBe "stratio/crossdata/crossdataClusterTest_ephemeralqueries"
+    streamingCatalog.ephemeralTableDAO.dao.entity shouldBe "stratio/crossdata/crossdataClusterTest_ephemeraltables"
+    streamingCatalog.ephemeralTableStatusDAO.dao.entity shouldBe "stratio/crossdata/crossdataClusterTest_ephemeraltablestatus"
   }
 
   it should "work with the default values if cluster name is not specified" in {

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/ZookeeperCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/ZookeeperCatalogSpec.scala
@@ -19,6 +19,7 @@ import com.stratio.crossdata.test.BaseXDTest
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.sql.catalyst.{CatalystConf, SimpleCatalystConf}
 import org.apache.spark.sql.crossdata.catalog.streaming.ZookeeperStreamingCatalog
+import org.apache.spark.sql.crossdata.config.CoreConfig
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -27,7 +28,8 @@ import org.scalatest.junit.JUnitRunner
 class ZookeeperCatalogSpec extends BaseXDTest {
 
   private class ZookeeperCatalogWithMockedConfig(override val catalystConf: CatalystConf) extends ZookeeperCatalog(catalystConf) {
-    override lazy val config: Config = ConfigFactory.load("catalogspec/zookeeper-catalog-test-properties.conf")
+    override lazy val config: Config =
+      ConfigFactory.load("catalogspec/zookeeper-catalog-test-properties.conf").getConfig(Seq(CoreConfig.ParentConfigName, CoreConfig.CatalogConfigKey) mkString ".")
   }
 
   it should "get the cluster name from the config" in {
@@ -39,7 +41,10 @@ class ZookeeperCatalogSpec extends BaseXDTest {
     catalog.indexDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/indexes"
 
     //Ephemeral
-    val streamingCatalog = new ZookeeperStreamingCatalog(new SimpleCatalystConf(true), ConfigFactory.load("catalogspec/zookeeper-streaming-catalog-with-prefix.conf"))
+    val streamingCatalog = new ZookeeperStreamingCatalog(
+      new SimpleCatalystConf(true),
+      ConfigFactory.load("catalogspec/zookeeper-streaming-catalog-with-prefix.conf").getConfig(CoreConfig.ParentConfigName)
+    )
     streamingCatalog.streamingConfig.getString("catalog.prefix") shouldBe "crossdataClusterTest"
     streamingCatalog.ephemeralQueriesDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/ephemeralqueries"
     streamingCatalog.ephemeralTableDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/ephemeraltables"
@@ -55,7 +60,10 @@ class ZookeeperCatalogSpec extends BaseXDTest {
     catalog.indexDAO.dao.entity shouldBe "stratio/crossdata/indexes"
 
     //Ephemeral
-    val streamingCatalog = new ZookeeperStreamingCatalog(new SimpleCatalystConf(true), ConfigFactory.load("catalogspec/zookeeper-streaming-catalog-without-prefix.conf"))
+    val streamingCatalog = new ZookeeperStreamingCatalog(
+      new SimpleCatalystConf(true),
+      ConfigFactory.load("catalogspec/zookeeper-streaming-catalog-without-prefix.conf").getConfig(CoreConfig.ParentConfigName)
+    )
     an[Exception] shouldBe thrownBy(catalog.config.getString("streaming.catalog.prefix"))
     streamingCatalog.ephemeralQueriesDAO.dao.entity shouldBe "stratio/crossdata/ephemeralqueries"
     streamingCatalog.ephemeralTableDAO.dao.entity shouldBe "stratio/crossdata/ephemeraltables"

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/ZookeeperCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/ZookeeperCatalogSpec.scala
@@ -45,7 +45,7 @@ class ZookeeperCatalogSpec extends BaseXDTest {
       new SimpleCatalystConf(true),
       ConfigFactory.load("catalogspec/zookeeper-streaming-catalog-with-prefix.conf").getConfig(CoreConfig.ParentConfigName)
     )
-    streamingCatalog.streamingConfig.getString("catalog.prefix") shouldBe "crossdataClusterTest"
+    streamingCatalog.streamingConfig.getString("catalog.zookeeper.prefix") shouldBe "crossdataClusterTest"
     streamingCatalog.ephemeralQueriesDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/ephemeralqueries"
     streamingCatalog.ephemeralTableDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/ephemeraltables"
     streamingCatalog.ephemeralTableStatusDAO.dao.entity shouldBe "crossdataClusterTest_stratio/crossdata/ephemeraltablestatus"
@@ -64,7 +64,7 @@ class ZookeeperCatalogSpec extends BaseXDTest {
       new SimpleCatalystConf(true),
       ConfigFactory.load("catalogspec/zookeeper-streaming-catalog-without-prefix.conf").getConfig(CoreConfig.ParentConfigName)
     )
-    an[Exception] shouldBe thrownBy(catalog.config.getString("streaming.catalog.prefix"))
+    an[Exception] shouldBe thrownBy(catalog.config.getString("streaming.catalog.zookeeper.prefix"))
     streamingCatalog.ephemeralQueriesDAO.dao.entity shouldBe "stratio/crossdata/ephemeralqueries"
     streamingCatalog.ephemeralTableDAO.dao.entity shouldBe "stratio/crossdata/ephemeraltables"
     streamingCatalog.ephemeralTableStatusDAO.dao.entity shouldBe "stratio/crossdata/ephemeraltablestatus"

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/ZookeeperCatalogSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/catalog/persistent/ZookeeperCatalogSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.crossdata.catalog.persistent
+
+import com.stratio.crossdata.test.BaseXDTest
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.spark.sql.catalyst.{CatalystConf, SimpleCatalystConf}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class ZookeeperCatalogSpec extends BaseXDTest {
+
+  private class ZookeeperCatalogWithMockedConfig(override val catalystConf: CatalystConf) extends ZookeeperCatalog(catalystConf) {
+    override lazy val config: Config = ConfigFactory.load("catalogspec/zookeeper-catalog-test-properties.conf")
+  }
+
+  it should "get the cluster name from the config" in {
+    val a = new ZookeeperCatalogWithMockedConfig(new SimpleCatalystConf(true))
+    a.config.getString("crossdata-core.catalog.clustername") shouldBe "crossdataClusterTest"
+    //TODO:println(a.tableDAO.dao.entity)
+  }
+
+}

--- a/dist/src/main/resources/server/core-application.conf
+++ b/dist/src/main/resources/server/core-application.conf
@@ -23,10 +23,9 @@ crossdata-core.external.config.filename = "/etc/sds/crossdata/server/core-applic
 #crossdata-core.catalog.jdbc.driver = "org.mariadb.jdbc.Driver"
 #crossdata-core.catalog.jdbc.url = "jdbc:mysql://127.0.0.1:3306/"
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
-#crossdata-core.catalog.jdbc.db.table = "crossdataTables"
-#crossdata-core.catalog.jdbc.db.view = "crossdataViews"
 #crossdata-core.catalog.jdbc.db.user = "root"
 #crossdata-core.catalog.jdbc.db.pass = "stratio"
+#crossdata-core.catalog.clustername = "crossdataCluster"
 
 
 ####### PostgreSQL ###########
@@ -34,10 +33,9 @@ crossdata-core.external.config.filename = "/etc/sds/crossdata/server/core-applic
 #crossdata-core.catalog.jdbc.driver = "org.postgresql.Driver"
 #crossdata-core.catalog.jdbc.url = "jdbc:postgresql://127.0.0.1:5432/"
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
-#crossdata-core.catalog.jdbc.db.table = "crossdataTables"
-#crossdata-core.catalog.jdbc.db.view = "crossdataViews"
 #crossdata-core.catalog.jdbc.db.user = "postgres"
 #crossdata-core.catalog.jdbc.db.pass = "postgres"
+#crossdata-core.catalog.clustername = "crossdataCluster"
 
 
 ####### Zookeeper Catalog Configuration ###########
@@ -47,6 +45,7 @@ crossdata-core.external.config.filename = "/etc/sds/crossdata/server/core-applic
 #crossdata-core.catalog.zookeeper.sessionTimeout = 60000
 #crossdata-core.catalog.zookeeper.retryAttempts = 5
 #crossdata-core.catalog.zookeeper.retryInterval = 10000
+#crossdata-core.catalog.clustername = "crossdataCluster"
 
 
 #####################################

--- a/dist/src/main/resources/server/core-application.conf
+++ b/dist/src/main/resources/server/core-application.conf
@@ -75,7 +75,7 @@ crossdata-core.jars.externalJars = "/var/sds/crossdata/externalJars"
 //crossdata-core.streaming.catalog.zookeeper.sessionTimeout = 60000
 //crossdata-core.streaming.catalog.zookeeper.retryAttempts = 5
 //crossdata-core.streaming.catalog.zookeeper.retryInterval = 10000
-//crossdata-core.streaming.catalog.prefix = "crossdataCluster"
+//crossdata-core.streaming.catalog.zookeeper.prefix = "crossdataCluster"
 //
 //
 //

--- a/dist/src/main/resources/server/core-application.conf
+++ b/dist/src/main/resources/server/core-application.conf
@@ -25,7 +25,7 @@ crossdata-core.external.config.filename = "/etc/sds/crossdata/server/core-applic
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
 #crossdata-core.catalog.jdbc.db.user = "root"
 #crossdata-core.catalog.jdbc.db.pass = "stratio"
-#crossdata-core.catalog.clustername = "crossdataCluster"
+#crossdata-core.catalog.prefix = "crossdataCluster"
 
 
 ####### PostgreSQL ###########
@@ -35,7 +35,7 @@ crossdata-core.external.config.filename = "/etc/sds/crossdata/server/core-applic
 #crossdata-core.catalog.jdbc.db.name = "crossdata"
 #crossdata-core.catalog.jdbc.db.user = "postgres"
 #crossdata-core.catalog.jdbc.db.pass = "postgres"
-#crossdata-core.catalog.clustername = "crossdataCluster"
+#crossdata-core.catalog.prefix = "crossdataCluster"
 
 
 ####### Zookeeper Catalog Configuration ###########
@@ -45,7 +45,7 @@ crossdata-core.external.config.filename = "/etc/sds/crossdata/server/core-applic
 #crossdata-core.catalog.zookeeper.sessionTimeout = 60000
 #crossdata-core.catalog.zookeeper.retryAttempts = 5
 #crossdata-core.catalog.zookeeper.retryInterval = 10000
-#crossdata-core.catalog.clustername = "crossdataCluster"
+#crossdata-core.catalog.prefix = "crossdataCluster"
 
 
 #####################################
@@ -75,6 +75,7 @@ crossdata-core.jars.externalJars = "/var/sds/crossdata/externalJars"
 //crossdata-core.streaming.catalog.zookeeper.sessionTimeout = 60000
 //crossdata-core.streaming.catalog.zookeeper.retryAttempts = 5
 //crossdata-core.streaming.catalog.zookeeper.retryInterval = 10000
+//crossdata-core.streaming.catalog.prefix = "crossdataCluster"
 //
 //
 //

--- a/streaming/src/main/scala/com/stratio/crossdata/streaming/CrossdataStreaming.scala
+++ b/streaming/src/main/scala/com/stratio/crossdata/streaming/CrossdataStreaming.scala
@@ -19,6 +19,7 @@ import com.stratio.crossdata.streaming.constants.ApplicationConstants._
 import com.stratio.crossdata.streaming.helpers.{CrossdataStatusHelper, CrossdataStreamingHelper}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.crossdata.config.StreamingConstants._
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
 import org.apache.spark.sql.crossdata.daos.EphemeralTableMapDAO
 import org.apache.spark.sql.crossdata.models._
 import org.apache.spark.streaming.StreamingContext
@@ -34,6 +35,8 @@ class CrossdataStreaming(ephemeralTableName: String,
     case (key, value) if key.startsWith(ZooKeeperStreamingCatalogPath) =>
       (key.substring(s"$ZooKeeperStreamingCatalogPath.".length), value)
   }
+
+  def prefix:String = Try(zookeeperCatalogConfig.get(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
 
   val memoryMap = Map(ZookeeperPrefixName -> zookeeperCatalogConfig)
 

--- a/streaming/src/main/scala/com/stratio/crossdata/streaming/CrossdataStreaming.scala
+++ b/streaming/src/main/scala/com/stratio/crossdata/streaming/CrossdataStreaming.scala
@@ -36,7 +36,7 @@ class CrossdataStreaming(ephemeralTableName: String,
       (key.substring(s"$ZooKeeperStreamingCatalogPath.".length), value)
   }
 
-  def prefix:String = Try(zookeeperCatalogConfig.get(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
+  def prefix:String = Try(zookeeperCatalogConfig.get(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
 
   val memoryMap = Map(ZookeeperPrefixName -> zookeeperCatalogConfig)
 

--- a/streaming/src/main/scala/com/stratio/crossdata/streaming/actors/EphemeralQueryActor.scala
+++ b/streaming/src/main/scala/com/stratio/crossdata/streaming/actors/EphemeralQueryActor.scala
@@ -18,6 +18,7 @@ package com.stratio.crossdata.streaming.actors
 import akka.actor.Actor
 import com.stratio.crossdata.streaming.actors.EphemeralQueryActor._
 import com.stratio.crossdata.streaming.constants.ApplicationConstants._
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
 import org.apache.spark.sql.crossdata.daos.EphemeralQueriesMapDAO
 import org.apache.spark.sql.crossdata.models.EphemeralQueryModel
 
@@ -28,6 +29,8 @@ with EphemeralQueriesMapDAO {
 
   val memoryMap = Map(ZookeeperPrefixName -> zookeeperConfiguration)
   var streamingQueries: List[EphemeralQueryModel] = dao.getAll()
+
+  def prefix:String = Try(config.getString(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
 
   import context.become
 

--- a/streaming/src/main/scala/com/stratio/crossdata/streaming/actors/EphemeralQueryActor.scala
+++ b/streaming/src/main/scala/com/stratio/crossdata/streaming/actors/EphemeralQueryActor.scala
@@ -30,7 +30,7 @@ with EphemeralQueriesMapDAO {
   val memoryMap = Map(ZookeeperPrefixName -> zookeeperConfiguration)
   var streamingQueries: List[EphemeralQueryModel] = dao.getAll()
 
-  def prefix:String = Try(config.getString(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
+  def prefix:String = Try(zookeeperConfiguration.get(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
 
   import context.become
 

--- a/streaming/src/main/scala/com/stratio/crossdata/streaming/actors/EphemeralQueryActor.scala
+++ b/streaming/src/main/scala/com/stratio/crossdata/streaming/actors/EphemeralQueryActor.scala
@@ -27,10 +27,10 @@ import scala.util.Try
 class EphemeralQueryActor(zookeeperConfiguration: Map[String, String]) extends Actor
 with EphemeralQueriesMapDAO {
 
-  val memoryMap = Map(ZookeeperPrefixName -> zookeeperConfiguration)
+  lazy val memoryMap = Map(ZookeeperPrefixName -> zookeeperConfiguration)
   var streamingQueries: List[EphemeralQueryModel] = dao.getAll()
 
-  def prefix:String = Try(zookeeperConfiguration.get(PrefixStreamingCatalogsConfig)+"_") getOrElse ("")
+  def prefix:String = Try(memoryMap.get(ZookeeperPrefixName).get(PrefixStreamingCatalogsConfigForActors)+"_") getOrElse ("")
 
   import context.become
 

--- a/streaming/src/main/scala/com/stratio/crossdata/streaming/actors/EphemeralStatusActor.scala
+++ b/streaming/src/main/scala/com/stratio/crossdata/streaming/actors/EphemeralStatusActor.scala
@@ -34,11 +34,11 @@ class EphemeralStatusActor(streamingContext: StreamingContext,
 with EphemeralTableStatusMapDAO {
 
   val ephemeralTMDao = new EphemeralTableMapDAO(Map(ZookeeperPrefixName -> zookeeperConfiguration))
-  val memoryMap = Map(ZookeeperPrefixName -> zookeeperConfiguration)
+  lazy val memoryMap = Map(ZookeeperPrefixName -> zookeeperConfiguration)
   var ephemeralStatus: Option[EphemeralStatusModel] = getRepositoryStatusTable
   var cancellableCheckStatus: Option[Cancellable] = None
 
-  def prefix:String = Try(config.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
+  def prefix:String = Try(memoryMap.get(ZookeeperPrefixName).get(PrefixStreamingCatalogsConfigForActors)+"_") getOrElse ("")
 
 
   override def receive: Receive = receive(listenerAdded = false)

--- a/streaming/src/main/scala/com/stratio/crossdata/streaming/actors/EphemeralStatusActor.scala
+++ b/streaming/src/main/scala/com/stratio/crossdata/streaming/actors/EphemeralStatusActor.scala
@@ -19,12 +19,14 @@ import akka.actor.{Actor, Cancellable}
 import com.github.nscala_time.time.Imports._
 import com.stratio.crossdata.streaming.actors.EphemeralStatusActor._
 import com.stratio.crossdata.streaming.constants.ApplicationConstants._
+import org.apache.spark.sql.crossdata.daos.DAOConstants._
 import org.apache.spark.sql.crossdata.daos.EphemeralTableStatusMapDAO
 import org.apache.spark.sql.crossdata.daos.impl.EphemeralTableMapDAO
 import org.apache.spark.sql.crossdata.models.{EphemeralExecutionStatus, EphemeralOptionsModel, EphemeralStatusModel}
 import org.apache.spark.streaming.{StreamingContext, StreamingContextState}
 
 import scala.concurrent.duration._
+import scala.util.Try
 
 class EphemeralStatusActor(streamingContext: StreamingContext,
                            zookeeperConfiguration: Map[String, String],
@@ -35,6 +37,9 @@ with EphemeralTableStatusMapDAO {
   val memoryMap = Map(ZookeeperPrefixName -> zookeeperConfiguration)
   var ephemeralStatus: Option[EphemeralStatusModel] = getRepositoryStatusTable
   var cancellableCheckStatus: Option[Cancellable] = None
+
+  def prefix:String = Try(config.getString(PrefixPermantCatalogsConfig)+"_") getOrElse ("")
+
 
   override def receive: Receive = receive(listenerAdded = false)
 

--- a/streaming/src/main/scala/com/stratio/crossdata/streaming/helpers/CrossdataStreamingHelper.scala
+++ b/streaming/src/main/scala/com/stratio/crossdata/streaming/helpers/CrossdataStreamingHelper.scala
@@ -56,6 +56,7 @@ object CrossdataStreamingHelper extends SparkLoggerComponent {
     // More information here:
     // http://spark.apache.org/docs/latest/streaming-programming-guide.html#design-patterns-for-using-foreachrdd
     kafkaDStream.foreachRDD { rdd =>
+
       if (rdd.take(1).length > 0) {
         val ephemeralQueries = CrossdataStatusHelper.queriesFromEphemeralTable(zookeeperConf, ephemeralTable.name)
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/kafka/CrossdataStreamingHelperProjectIT.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/kafka/CrossdataStreamingHelperProjectIT.scala
@@ -53,7 +53,7 @@ class CrossdataStreamingHelperProjectIT extends BaseSparkStreamingXDTest with Co
     if (kafkaTestUtils == null) {
       kafkaTestUtils = new KafkaTestUtils
       kafkaTestUtils.setup()
-      zookeeperConf = Map("connectionString" -> kafkaTestUtils.zkAddress)
+      zookeeperConf = Map("connectionString" -> kafkaTestUtils.zkAddress, "prefix" -> "crossdataCluster")
       catalogConf = parseZookeeperCatalogConfig(zookeeperConf)
       xDContext = XDContext.getOrCreate(sc, parseCatalogConfig(catalogConf))
       zookeeperStreamingCatalog = new ZookeeperStreamingCatalog(new SimpleCatalystConf(true), XDContext.xdConfig) //TODO Replace XDContext.xdConfig when refactoring CoreConfig


### PR DESCRIPTION
## Description
Allowing to set a prefix to the catalog stored in Zookeeper/MySQL/PostgreSQL. This allows you to share a catalog between different clusters, and also to have two different clusters working under the same database.

### Testing
- [x] Unit, integration tests

### Documentation
- [ ] Changelog update
- [ ] Documentation link
