### PR TITLE
[CROSSDATA-588] Each command envelope now includes the user associated to the session.

### DIFF
--- a/common/src/main/scala/com/stratio/crossdata/common/messages.scala
+++ b/common/src/main/scala/com/stratio/crossdata/common/messages.scala
@@ -98,8 +98,12 @@ private[crossdata] case class GetJobStatus() extends ControlCommand
 
 private[crossdata] case class CancelQueryExecution(queryId: UUID) extends ControlCommand
 
-private[crossdata] case class CommandEnvelope(cmd: Command, session: Session)
-
+/*
+  Note that this message implies that the server trust the client in regard to the relation between the session id
+   and the user. This assumption will be taken for granted until the model of session management changes from
+   trusted-client management to server management.
+ */
+private[crossdata] case class CommandEnvelope(cmd: Command, session: Session, user: String)
 
 // Server -> Driver messages
 private[crossdata] trait ServerReply {

--- a/driver/src/main/scala/com/stratio/crossdata/driver/Driver.scala
+++ b/driver/src/main/scala/com/stratio/crossdata/driver/Driver.scala
@@ -406,7 +406,7 @@ class Driver private(private[crossdata] val driverConf: DriverConf,
   }
 
   private def securitizeCommand(command: Command): CommandEnvelope =
-    new CommandEnvelope(command, driverSession)
+    new CommandEnvelope(command, driverSession, auth.user)
 
 
   private def getFlattenedFields(fieldName: String, dataType: DataType): Seq[FieldMetadata] = dataType match {

--- a/driver/src/main/scala/com/stratio/crossdata/driver/actor/ProxyActor.scala
+++ b/driver/src/main/scala/com/stratio/crossdata/driver/actor/ProxyActor.scala
@@ -73,23 +73,23 @@ class ProxyActor(clusterClientActor: ActorRef, driver: Driver) extends Actor {
   // Process messages from the Crossdata Driver.
   def sendToServer(promisesByIds: PromisesByIds): Receive = {
 
-    case secureSQLCommand @ CommandEnvelope(sqlCommand: SQLCommand, _) =>
+    case secureSQLCommand @ CommandEnvelope(sqlCommand: SQLCommand, _, _) =>
       logger.info(s"Sending query: ${sqlCommand.sql} with requestID=${sqlCommand.requestId} & queryID=${sqlCommand.queryId}")
       clusterClientActor ! ClusterClient.Send(ServerClusterClientParameters.ServerPath, secureSQLCommand, localAffinity = false)
 
-    case secureSQLCommand @ CommandEnvelope(addJARCommand @ AddJARCommand(path, _, _, _), session) =>
+    case secureSQLCommand @ CommandEnvelope(addJARCommand @ AddJARCommand(path, _, _, _), session, _) =>
       import context.dispatcher
       val shipmentResponse: Future[SQLReply] = sendJarToServers(addJARCommand, path, session)
       shipmentResponse pipeTo sender
 
-    case secureSQLCommand @ CommandEnvelope(clusterStateCommand: ClusterStateCommand, _) =>
+    case secureSQLCommand @ CommandEnvelope(clusterStateCommand: ClusterStateCommand, _, _) =>
       logger.debug(s"Send cluster state with requestID=${clusterStateCommand.requestId}")
       clusterClientActor ! ClusterClient.Send(ServerClusterClientParameters.ServerPath, secureSQLCommand, localAffinity = false)
 
-    case secureSQLCommand @ CommandEnvelope(aCmd @ AddAppCommand(path, alias, clss, _), _) =>
+    case secureSQLCommand @ CommandEnvelope(aCmd @ AddAppCommand(path, alias, clss, _), _, _) =>
       clusterClientActor ! ClusterClient.Send(ServerClusterClientParameters.ServerPath,secureSQLCommand, localAffinity=false)
 
-    case secureSQLCommand @ CommandEnvelope(_: OpenSessionCommand | _: CloseSessionCommand, _) =>
+    case secureSQLCommand @ CommandEnvelope(_: OpenSessionCommand | _: CloseSessionCommand, _, _) =>
       clusterClientActor ! ClusterClient.Send(ServerClusterClientParameters.ServerPath, secureSQLCommand, localAffinity = true)
 
     case sqlCommand: SQLCommand =>

--- a/server/src/main/scala/com/stratio/crossdata/server/CrossdataHttpServer.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/CrossdataHttpServer.scala
@@ -73,6 +73,7 @@ class CrossdataHttpServer(config: Config, serverActor: ActorRef, implicit val sy
             val hdfsConfig = XDContext.xdConfig.getConfig("hdfs")
             val hdfsPath = writeJarToHdfs(hdfsConfig, path)
             val session = Session(sessionUUID, null)
+            val user = "fileupload"
             allParts.values.toSeq.foreach{
               case file: File =>
                 file.delete
@@ -80,7 +81,7 @@ class CrossdataHttpServer(config: Config, serverActor: ActorRef, implicit val sy
               case _ => logger.error("Problem deleting the temporary file.")
             }
             //Send a broadcast message to all servers
-            mediator ! Publish(AddJarTopic, CommandEnvelope(AddJARCommand(hdfsPath, hdfsConfig = Option(hdfsConfig)), session))
+            mediator ! Publish(AddJarTopic, CommandEnvelope(AddJARCommand(hdfsPath, hdfsConfig = Option(hdfsConfig)), session, user))
             hdfsPath
           }
         }

--- a/server/src/main/scala/com/stratio/crossdata/server/actors/ResourceManagerActor.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/actors/ResourceManagerActor.scala
@@ -75,7 +75,7 @@ class ResourceManagerActor(cluster: Cluster, sessionProvider: XDSessionProvider)
 
   // Commands reception: Checks whether the command can be run at this Server passing it to the execution method if so
   def AddJarMessages(st: State): Receive = {
-    case CommandEnvelope(addJarCommand: AddJARCommand, session@Session(id, requester)) =>
+    case CommandEnvelope(addJarCommand: AddJARCommand, session@Session(id, requester), _) =>
       logger.debug(s"Add JAR received ${addJarCommand.requestId}: ${addJarCommand.path}. Actor ${self.path.toStringWithoutAddress}")
       logger.debug(s"Session identifier $session")
       //TODO  Maybe include job controller if it is necessary as in sql command

--- a/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
@@ -101,7 +101,7 @@ class ServerActor(cluster: Cluster, sessionProvider: XDSessionProvider)
     * @param st
     */
   private def executeAccepted(cmd: CommandEnvelope)(st: State): Unit = cmd match {
-    case CommandEnvelope(sqlCommand@SQLCommand(query, queryId, withColnames, timeout), session@Session(id, requester)) =>
+    case CommandEnvelope(sqlCommand@SQLCommand(query, queryId, withColnames, timeout), session@Session(id, requester), _) =>
       logger.debug(s"Query received $queryId: $query. Actor ${self.path.toStringWithoutAddress}")
       logger.debug(s"Session identifier $session")
 
@@ -119,13 +119,13 @@ class ServerActor(cluster: Cluster, sessionProvider: XDSessionProvider)
       }
 
 
-    case CommandEnvelope(addAppCommand@AddAppCommand(path, alias, clss, _), session@Session(id, requester)) =>
+    case CommandEnvelope(addAppCommand@AddAppCommand(path, alias, clss, _), session@Session(id, requester), _) =>
       if ( sessionProvider.session(id).map(_.addApp(path, clss, alias)).getOrElse(None).isDefined)// TODO improve addJar sessionManagement
         sender ! SQLReply(addAppCommand.requestId, SuccessfulSQLResult(Array.empty, new StructType()))
       else
         sender ! SQLReply(addAppCommand.requestId, ErrorSQLResult("App can't be stored in the catalog"))
 
-    case CommandEnvelope(cc@CancelQueryExecution(queryId), session@Session(id, requester)) =>
+    case CommandEnvelope(cc@CancelQueryExecution(queryId), session@Session(id, requester), _) =>
       st.jobsById.get(JobId(requester, id, queryId)).get ! CancelJob
   }
 
@@ -139,7 +139,7 @@ class ServerActor(cluster: Cluster, sessionProvider: XDSessionProvider)
     case DelegateCommand(cmd, broadcaster) if broadcaster != self =>
       cmd match {
         // Inner pattern matching for future delegated command validations
-        case sc@CommandEnvelope(CancelQueryExecution(queryId), Session(sid, requester)) =>
+        case sc@CommandEnvelope(CancelQueryExecution(queryId), Session(sid, requester), _) =>
           st.jobsById.get(JobId(requester, sid, queryId)) foreach (_ => executeAccepted(sc)(st))
         /* If it doesn't validate it won't be re-broadcast since the source server already distributed it to all
             servers through the topic. */
@@ -149,16 +149,16 @@ class ServerActor(cluster: Cluster, sessionProvider: XDSessionProvider)
   // Commands reception: Checks whether the command can be run at this Server passing it to the execution method if so
   def commandMessagesRec(st: State): Receive = {
 
-    case sc@CommandEnvelope(_: SQLCommand, _) =>
+    case sc@CommandEnvelope(_: SQLCommand, _, _) =>
       executeAccepted(sc)(st)
 
-    case sc@CommandEnvelope(_: AddJARCommand, _) =>
+    case sc@CommandEnvelope(_: AddJARCommand, _, _) =>
       executeAccepted(sc)(st)
 
-    case sc@CommandEnvelope(_: AddAppCommand, _) =>
+    case sc@CommandEnvelope(_: AddAppCommand, _, _) =>
       executeAccepted(sc)(st)
 
-    case sc@CommandEnvelope(cc: ControlCommand, session@Session(id, requester)) =>
+    case sc@CommandEnvelope(cc: ControlCommand, session@Session(id, requester), _) =>
       st.jobsById.get(JobId(requester, id, cc.requestId)) map { _ =>
         executeAccepted(sc)(st) // Command validated to be executed by this server.
       } getOrElse {
@@ -166,10 +166,10 @@ class ServerActor(cluster: Cluster, sessionProvider: XDSessionProvider)
         mediator ! Publish(ManagementTopic, DelegateCommand(sc, self))
       }
 
-    case sc@CommandEnvelope(_: ClusterStateCommand, session) =>
+    case sc@CommandEnvelope(_: ClusterStateCommand, session, _) =>
       sender ! ClusterStateReply(sc.cmd.requestId, cluster.state)
 
-    case sc@CommandEnvelope(_: OpenSessionCommand, session) =>
+    case sc@CommandEnvelope(_: OpenSessionCommand, session, _) =>
       val open = sessionProvider.newSession(session.id) match {
         case Success(_) =>
           logger.debug(s"new session with sessionID=${session.id} has been created")
@@ -183,7 +183,7 @@ class ServerActor(cluster: Cluster, sessionProvider: XDSessionProvider)
 
       context.actorSelection("/user/client-monitor") ! DoCheck(session.id, expectedClientHeartbeatPeriod)
 
-    case sc@CommandEnvelope(_: CloseSessionCommand, session) =>
+    case sc@CommandEnvelope(_: CloseSessionCommand, session, _) =>
       closeSessionTerminatingJobs(session.id)(st)
       /* Note that the client monitoring isn't explicitly stopped. It'll after the first miss
           is detected, right after the driver has ended its session. */


### PR DESCRIPTION
## Description

A mechanism to link session ids to user ids is needed. Since the client will be considered a trusted agent (indeed it is the client who generates the session id) and the channel integrity will be guaranteed, there is no problem in sending the user along side the session id within each `CommandEnvelope` message. Thus reducing the boilerplate this functionality would require if a relation table were keep at server side.



