### PR TITLE
Elastic date type

### DIFF
--- a/elasticsearch/src/main/scala/org/elasticsearch/spark/sql/ElasticsearchXDRelation.scala
+++ b/elasticsearch/src/main/scala/org/elasticsearch/spark/sql/ElasticsearchXDRelation.scala
@@ -15,16 +15,67 @@
  */
 package org.elasticsearch.spark.sql
 
+import java.sql.{Date, Timestamp}
+import javax.xml.bind.DatatypeConverter
+
 import com.stratio.crossdata.connector.NativeScan
 import com.stratio.crossdata.connector.elasticsearch.ElasticSearchQueryProcessor
-import org.apache.spark.Logging
-
-import org.apache.spark.sql.catalyst.plans.logical.{Project, UnaryNode, LeafNode, LogicalPlan}
-
-import org.apache.spark.sql.catalyst.plans.logical.{Filter, Limit}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, Project, UnaryNode, Filter => FilterPlan}
+import org.apache.spark.sql.catalyst.plans.logical.Limit
+import org.apache.spark.sql.sources._
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SQLContext}
+import org.elasticsearch.hadoop.cfg.{ConfigurationOptions, InternalConfigurationOptions}
+import org.elasticsearch.hadoop.rest.RestService.PartitionDefinition
+import org.elasticsearch.hadoop.serialization.json.JacksonJsonGenerator
+import org.elasticsearch.hadoop.util.{FastByteArrayOutputStream, IOUtils, StringUtils}
+import org.elasticsearch.spark.rdd.EsPartition
 
+import scala.collection.mutable
+import scala.collection.mutable.LinkedHashSet
+
+import java.util.{Date => UDate, Calendar, Locale}
+
+class ScalaXDEsRowRDDIterator(
+                               context: TaskContext,
+                               partition: PartitionDefinition,
+                               schema: SchemaUtils.Schema,
+                               userSchema: Option[StructType]
+                             ) extends ScalaEsRowRDDIterator(context, partition, schema) {
+
+  override def createValue(value: Array[Object]): Row = {
+    val v: ScalaEsRow = super.createValue(value).asInstanceOf[ScalaEsRow]
+    userSchema foreach { uschema: StructType =>
+
+      val name2expectedType: Map[String, DataType] = uschema.map(field => field.name -> field.dataType).toMap
+      val transformations: Map[String, Any => Any] = name2expectedType.collect {
+        case (k, _: DateType) => k -> ((timestamp: Any) => new Date(timestamp.asInstanceOf[Timestamp].getTime))
+      }
+
+      for(
+        ((value, name), idx) <- (v.values zip v.rowOrder) zipWithIndex;
+        trans <- transformations.get(name)
+      ) v.values.update(idx, trans(value))
+    }
+
+    v
+  }
+
+}
+
+class ScalaXDEsRowRDD(
+                       @transient sc: SparkContext,
+                       params: mutable.Map[String, String] = mutable.Map.empty,
+                       schema: SchemaUtils.Schema,
+                       userSchema: Option[StructType]
+                     ) extends ScalaEsRowRDD(sc, params, schema) {
+
+  override def compute(split: Partition, context: TaskContext): ScalaEsRowRDDIterator = {
+    new ScalaXDEsRowRDDIterator(context, split.asInstanceOf[EsPartition].esPartition, schema, userSchema)
+  }
+
+}
 
 /**
  * ElasticSearchXDRelation inherits from <code>ElasticsearchRelation</code>
@@ -37,9 +88,275 @@ import org.apache.spark.sql.{Row, SQLContext}
 class ElasticsearchXDRelation(parameters: Map[String, String], sqlContext: SQLContext, userSchema: Option[StructType] = None)
   extends ElasticsearchRelation(parameters, sqlContext, userSchema) with NativeScan with Logging {
 
+  private object CopiedCode {
+
+    def isClass(obj: Any, className: String) = {
+    className.equals(obj.getClass().getName())
+  }
+
+    def extract(value: Any): String = {
+    extract(value, true, false)
+  }
+
+    def extractAsJsonArray(value: Any): String = { extract(value, true, true) }
+
+    def extractMatchArray(attribute: String, ar: Array[Any]): String = {
+    // use a set to avoid duplicate values
+    // especially since Spark conversion might turn each user param into null
+    val numbers = LinkedHashSet.empty[AnyRef]
+    val strings = LinkedHashSet.empty[AnyRef]
+
+    // move numbers into a separate list for a terms query combined with a bool
+    for (i <- ar) i.asInstanceOf[AnyRef] match {
+      case null => // ignore
+      case n: Number => numbers += extract(i, false, false)
+      case _ => strings += extract(i, false, false)
+    }
+
+    if (numbers.isEmpty) {
+      if (strings.isEmpty) {
+        return StringUtils.EMPTY
+      }
+      return s"""{"query":{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}}"""
+      //s"""{"query":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
+    }
+    else {
+      // translate the numbers into a terms query
+      val str =
+      s"""{"terms":{"$attribute":${numbers.mkString("[", ",", "]")}}}"""
+      if (strings.isEmpty) return str
+      // if needed, add the strings as a match query
+      else return str + s""",{"query":{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}}"""
+    }
+  }
+
+    def extract(value: Any, inJsonFormat: Boolean, asJsonArray: Boolean): String = {
+    // common-case implies primitives and String so try these before using the full-blown ValueWriter
+    value match {
+      case null => "null"
+      case u: Unit => "null"
+      case b: Boolean => b.toString
+      case by: Byte => by.toString
+      case s: Short => s.toString
+      case i: Int => i.toString
+      case l: Long => l.toString
+      case f: Float => f.toString
+      case d: Double => d.toString
+      case bd: BigDecimal => bd.toString
+      case _: Char |
+           _: String |
+           _: Array[Byte] => if (inJsonFormat) StringUtils.toJsonString(value.toString) else value.toString()
+      // handle Timestamp also
+      case dt: UDate => {
+        val cal = Calendar.getInstance()
+        cal.setTime(dt)
+        val str = DatatypeConverter.printDateTime(cal)
+        if (inJsonFormat) StringUtils.toJsonString(str) else str
+      }
+      case ar: Array[Any] =>
+        if (asJsonArray) (for (i <- ar) yield extract(i, true, false)).distinct.mkString("[", ",", "]")
+        else (for (i <- ar) yield extract(i, false, false)).distinct.mkString("\"", " ", "\"")
+      // new in Spark 1.4
+      case utf if (isClass(utf, "org.apache.spark.sql.types.UTF8String")
+        // new in Spark 1.5
+        || isClass(utf, "org.apache.spark.unsafe.types.UTF8String"))
+      => if (inJsonFormat) StringUtils.toJsonString(utf.toString()) else utf.toString()
+      case a: AnyRef => {
+        val storage = new FastByteArrayOutputStream()
+        val generator = new JacksonJsonGenerator(storage)
+        valueWriter.write(a, generator)
+        generator.flush()
+        generator.close()
+        storage.toString()
+      }
+    }
+  }
+
+    // string interpolation FTW
+    def translateFilter(filter: Filter, strictPushDown: Boolean): String = {
+    // the pushdown can be strict - i.e. use only filters and thus match the value exactly (works with non-analyzed)
+    // or non-strict meaning queries will be used instead that is the filters will be analyzed as well
+    filter match {
+
+      case EqualTo(attribute, value) => {
+        // if we get a null, translate it into a missing query (we're extra careful - Spark should translate the equals into isMissing anyway)
+        if (value == null || value == None || value == Unit) {
+          return s"""{"missing":{"field":"$attribute"}}"""
+        }
+
+        if (strictPushDown)
+          s"""{"term":{"$attribute":${extract(value)}}}"""
+        else
+          s"""{"query":{"match":{"$attribute":${extract(value)}}}}"""
+      }
+      case GreaterThan(attribute, value) => s"""{"range":{"$attribute":{"gt" :${extract(value)}}}}"""
+      case GreaterThanOrEqual(attribute, value) => s"""{"range":{"$attribute":{"gte":${extract(value)}}}}"""
+      case LessThan(attribute, value) => s"""{"range":{"$attribute":{"lt" :${extract(value)}}}}"""
+      case LessThanOrEqual(attribute, value) => s"""{"range":{"$attribute":{"lte":${extract(value)}}}}"""
+      case In(attribute, values) => {
+        // when dealing with mixed types (strings and numbers) Spark converts the Strings to null (gets confused by the type field)
+        // this leads to incorrect query DSL hence why nulls are filtered
+        val filtered = values filter (_ != null)
+        if (filtered.isEmpty) {
+          return ""
+        }
+
+        // further more, match query only makes sense with String types so for other types apply a terms query (aka strictPushDown)
+        val attrType = lazySchema.struct(attribute).dataType
+        val isStrictType = attrType match {
+          case DateType |
+               TimestampType => true
+          case _ => false
+        }
+
+        if (!strictPushDown && isStrictType) {
+          if (Utils.LOGGER.isDebugEnabled()) {
+            Utils.LOGGER.debug(s"Attribute $attribute type $attrType not suitable for match query; using terms (strict) instead")
+          }
+        }
+
+        if (strictPushDown || isStrictType)
+          s"""{"terms":{"$attribute":${extractAsJsonArray(filtered)}}}"""
+        else
+          s"""{"or":{"filters":[${extractMatchArray(attribute, filtered)}]}}"""
+      }
+      case IsNull(attribute) => s"""{"missing":{"field":"$attribute"}}"""
+      case IsNotNull(attribute) => s"""{"exists":{"field":"$attribute"}}"""
+      case And(left, right) => s"""{"and":{"filters":[${translateFilter(left, strictPushDown)}, ${translateFilter(right, strictPushDown)}]}}"""
+      case Or(left, right) => s"""{"or":{"filters":[${translateFilter(left, strictPushDown)}, ${translateFilter(right, strictPushDown)}]}}"""
+      case Not(filterToNeg) => s"""{"not":{"filter":${translateFilter(filterToNeg, strictPushDown)}}}"""
+
+      // the filter below are available only from Spark 1.3.1 (not 1.3.0)
+
+      //
+      // String Filter notes:
+      //
+      // the DSL will be quite slow (linear to the number of terms in the index) but there's no easy way around them
+      // we could use regexp filter however it's a bit overkill and there are plenty of chars to escape
+      // s"""{"regexp":{"$attribute":"$value.*"}}"""
+      // as an alternative we could use a query string but still, the analyzed / non-analyzed is there as the DSL is slightly more complicated
+      // s"""{"query":{"query_string":{"default_field":"$attribute","query":"$value*"}}}"""
+      // instead wildcard query is used, with the value lowercased (to match analyzed fields)
+
+      case f: Product if isClass(f, "org.apache.spark.sql.sources.StringStartsWith") => {
+        var arg = f.productElement(1).toString()
+        if (!strictPushDown) {
+          arg = arg.toLowerCase(Locale.ROOT)
+        }
+        s"""{"query":{"wildcard":{"${f.productElement(0)}":"$arg*"}}}"""
+      }
+
+      case f: Product if isClass(f, "org.apache.spark.sql.sources.StringEndsWith") => {
+        var arg = f.productElement(1).toString()
+        if (!strictPushDown) {
+          arg = arg.toLowerCase(Locale.ROOT)
+        }
+        s"""{"query":{"wildcard":{"${f.productElement(0)}":"*$arg"}}}"""
+      }
+
+      case f: Product if isClass(f, "org.apache.spark.sql.sources.StringContains") => {
+        var arg = f.productElement(1).toString()
+        if (!strictPushDown) {
+          arg = arg.toLowerCase(Locale.ROOT)
+        }
+        s"""{"query":{"wildcard":{"${f.productElement(0)}":"*$arg*"}}}"""
+      }
+
+      // the filters below are available only from Spark 1.5.0
+
+      case f: Product if isClass(f, "org.apache.spark.sql.sources.EqualNullSafe") => {
+        var arg = extract(f.productElement(1))
+        if (strictPushDown)
+          s"""{"term":{"${f.productElement(0)}":$arg}}"""
+        else
+          s"""{"query":{"match":{"${f.productElement(0)}":$arg}}}"""
+      }
+
+      case _ => ""
+    }
+  }
+
+    def createDSLFromFilters(filters: Array[Filter], strictPushDown: Boolean) = {
+      filters.map(filter => translateFilter(filter, strictPushDown)).filter(query => StringUtils.hasText(query))
+    }
+
+  }
+
+  /* TODO: Once an artifact including this change (https://github.com/elastic/elasticsearch-hadoop/pull/826),
+  remove all the duplicated code within `CopiedCode` as well as the current overriden implementation of `buildScan`
+   and DO UNCOMMENT the following implementation.
+
+
+  override def buildScan(requiredColumns: Array[String], filters: Array[Filter]) = {
+    val rdd = super.buildScan(requiredColumns, filters)
+    userSchema map { uschema: StructType =>
+      val name2expectedType: Map[String, DataType] = uschema.map(field => field.name -> field.dataType).toMap
+
+      val transformations: Map[String, Any => Any] = name2expectedType.collect {
+        case (k, _: DateType) => k -> ((timestamp: Any) => new Date(timestamp.asInstanceOf[Timestamp].getTime))
+      }
+      rdd.map {
+        case esRow: ScalaEsRow =>
+          lazy val newRow = esRow.copy()
+          var hasChanges = false
+
+          for(
+            ((value, name), idx) <- (esRow.values zip esRow.rowOrder) zipWithIndex;
+            trans <- transformations.get(name)
+          ) {
+            hasChanges = true
+            newRow.values.update(idx, trans(value))
+          }
+
+          (if(hasChanges) newRow else esRow) : Row
+
+        case other: Row => other
+      }
+    } getOrElse rdd
+  }*/
+
+  // PrunedFilteredScan
+  override def buildScan(requiredColumns: Array[String], filters: Array[Filter]) = {
+    import CopiedCode._
+    val paramWithScan = mutable.LinkedHashMap[String, String]() ++ parameters
+    paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS ->
+      StringUtils.concatenate(requiredColumns.asInstanceOf[Array[Object]], StringUtils.DEFAULT_DELIMITER))
+
+    // scroll fields only apply to source fields; handle metadata separately
+    if (cfg.getReadMetadata) {
+      val metadata = cfg.getReadMetadataField
+      // if metadata is not selected, don't ask for it
+      if (!requiredColumns.contains(metadata)) {
+        paramWithScan += (ConfigurationOptions.ES_READ_METADATA -> false.toString())
+      }
+    }
+
+    if (filters != null && filters.size > 0) {
+      if (Utils.isPushDown(cfg)) {
+        if (Utils.LOGGER.isDebugEnabled()) {
+          Utils.LOGGER.debug(s"Pushing down filters ${filters.mkString("[", ",", "]")}")
+        }
+        val filterString = createDSLFromFilters(filters, Utils.isPushDownStrict(cfg))
+
+        if (Utils.LOGGER.isTraceEnabled()) {
+          Utils.LOGGER.trace(s"Transformed filters into DSL ${filterString.mkString("[", ",", "]")}")
+        }
+        paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_QUERY_FILTERS -> IOUtils.serializeToBase64(filterString))
+      }
+      else {
+        if (Utils.LOGGER.isTraceEnabled()) {
+          Utils.LOGGER.trace("Push-down is disabled; ignoring Spark filters...")
+        }
+      }
+    }
+
+    new ScalaXDEsRowRDD(sqlContext.sparkContext, paramWithScan, lazySchema, userSchema)
+  }
+
   /**
    * Build and Execute a NativeScan for the [[LogicalPlan]] provided.
-   * @param optimizedLogicalPlan the [[LogicalPlan]] to be executed
+    *
+    * @param optimizedLogicalPlan the [[LogicalPlan]] to be executed
    * @return a list of Spark [[Row]] with the [[LogicalPlan]] execution result.
    */
   override def buildScan(optimizedLogicalPlan: LogicalPlan): Option[Array[Row]] = {
@@ -59,7 +376,7 @@ class ElasticsearchXDRelation(parameters: Map[String, String], sqlContext: SQLCo
   override def isSupported(logicalStep: LogicalPlan, wholeLogicalPlan: LogicalPlan): Boolean = logicalStep match {
     case ln: LeafNode => true // TODO leafNode == LogicalRelation(xdSourceRelation)
     case un: UnaryNode => un match {
-      case Project(_, _) | Filter(_, _)  => true
+      case Project(_, _) | FilterPlan(_, _)  => true
       case Limit(_, _)=> false //TODO add support to others
       case _ => false
 

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticDataTypesWithSharedContext.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticDataTypesWithSharedContext.scala
@@ -53,7 +53,7 @@ trait ElasticDataTypesWithSharedContext extends SharedXDContextWithDataTest with
     ESColumnMetadata("description", "STRING", "description" typed StringType, () => "1", _ shouldBe a[java.lang.String]),
     ESColumnMetadata("name", "STRING", "name" typed StringType index NotAnalyzed, () => "1", _ shouldBe a[java.lang.String]),
     ESColumnMetadata("enrolled", "BOOLEAN", "enrolled" typed BooleanType, () => false, _ shouldBe a[java.lang.Boolean]),
-    //ESColumnMetadata("birthday", "DATE", "birthday" typed DateType, () => DateTime.parse(1980 + "-01-01T10:00:00-00:00").toDate, _ shouldBe a [java.sql.Date]), // TODO date should be timestamp (if not supported by elastic natively)
+    ESColumnMetadata("birthday", "DATE", "birthday" typed DateType, () => DateTime.parse(1980 + "-01-01T10:00:00-00:00").toDate, _ shouldBe a [java.sql.Date]),
     ESColumnMetadata("salary", "DOUBLE", "salary" typed DoubleType, () => 0.15, _ shouldBe a[java.lang.Double]),
     ESColumnMetadata("timecol", "TIMESTAMP", "timecol" typed DateType, () => new java.sql.Timestamp(new GregorianCalendar(1970, 0, 1, 0, 0, 0).getTimeInMillis), _ shouldBe a[java.sql.Timestamp])
     //ESColumnMetadata("float", "FLOAT", "float" typed FloatType, () => 0.15, _ shouldBe a[java.lang.Float]), // TODO float not supported natively

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticDataTypesWithSharedContext.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticDataTypesWithSharedContext.scala
@@ -15,7 +15,7 @@
  */
 package com.stratio.crossdata.connector.elasticsearch
 
-import java.util.UUID
+import java.util.{GregorianCalendar, UUID}
 
 import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.ElasticDsl._
@@ -54,7 +54,8 @@ trait ElasticDataTypesWithSharedContext extends SharedXDContextWithDataTest with
     ESColumnMetadata("name", "STRING", "name" typed StringType index NotAnalyzed, () => "1", _ shouldBe a[java.lang.String]),
     ESColumnMetadata("enrolled", "BOOLEAN", "enrolled" typed BooleanType, () => false, _ shouldBe a[java.lang.Boolean]),
     //ESColumnMetadata("birthday", "DATE", "birthday" typed DateType, () => DateTime.parse(1980 + "-01-01T10:00:00-00:00").toDate, _ shouldBe a [java.sql.Date]), // TODO date should be timestamp (if not supported by elastic natively)
-    ESColumnMetadata("salary", "DOUBLE", "salary" typed DoubleType, () => 0.15, _ shouldBe a[java.lang.Double])
+    ESColumnMetadata("salary", "DOUBLE", "salary" typed DoubleType, () => 0.15, _ shouldBe a[java.lang.Double]),
+    ESColumnMetadata("timecol", "TIMESTAMP", "timecol" typed DateType, () => new java.sql.Timestamp(new GregorianCalendar(1970, 0, 1, 0, 0, 0).getTimeInMillis), _ shouldBe a[java.sql.Timestamp])
     //ESColumnMetadata("float", "FLOAT", "float" typed FloatType, () => 0.15, _ shouldBe a[java.lang.Float]), // TODO float not supported natively
     //ESColumnMetadata("binary", "BINARY", "binary" typed BinaryType, () => Array(Byte.MaxValue, Byte.MinValue), x => x.isInstanceOf[Array[Byte]] shouldBe true) // TODO native and spark ko
     //ESColumnMetadata("tinyint", "TINYINT", "tinyint" typed ByteType, () => Byte.MinValue, _ shouldBe a[java.lang.Byte]), // TODO native ko

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticDataTypesWithSharedContext.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticDataTypesWithSharedContext.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.crossdata.connector.elasticsearch
+
+import java.util.UUID
+
+import com.sksamuel.elastic4s.ElasticClient
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.mappings.FieldType._
+import com.sksamuel.elastic4s.mappings.{MappingDefinition, TypedFieldDefinition}
+import com.stratio.common.utils.components.logger.impl.SparkLoggerComponent
+import com.typesafe.config.ConfigFactory
+import org.apache.spark.sql.crossdata.test.SharedXDContextWithDataTest
+import org.apache.spark.sql.crossdata.test.SharedXDContextWithDataTest.SparkTable
+import org.elasticsearch.common.settings.ImmutableSettings
+import org.scalatest.Suite
+
+import scala.util.Try
+
+
+trait ElasticDataTypesWithSharedContext extends SharedXDContextWithDataTest with ElasticSearchDataTypesDefaultConstants with SparkLoggerComponent {
+  this: Suite =>
+
+  override type ClientParams = ElasticClient
+  override val provider: String = SourceProvider
+
+  override val defaultOptions = Map(
+    "resource" -> s"$Index/$Type",
+    "es.nodes" -> s"$ElasticHost",
+    "es.port" -> s"$ElasticRestPort",
+    "es.nativePort" -> s"$ElasticNativePort",
+    "es.cluster" -> s"$ElasticClusterName"
+  )
+
+  case class ESColumnMetadata(fieldName: String, sparkSqlType: String, elasticType: TypedFieldDefinition, data: () => Any, typeValidation: Any => Unit)
+
+  val dataTest = Seq(
+    ESColumnMetadata("id", "INT", "id" typed IntegerType, () => 1, _ shouldBe a[java.lang.Integer]),
+    ESColumnMetadata("age", "LONG", "age" typed LongType, () => 1, _ shouldBe a[java.lang.Long]),
+    ESColumnMetadata("description", "STRING", "description" typed StringType, () => "1", _ shouldBe a[java.lang.String]),
+    ESColumnMetadata("name", "STRING", "name" typed StringType index NotAnalyzed, () => "1", _ shouldBe a[java.lang.String]),
+    ESColumnMetadata("enrolled", "BOOLEAN", "enrolled" typed BooleanType, () => false, _ shouldBe a[java.lang.Boolean]),
+    //ESColumnMetadata("birthday", "DATE", "birthday" typed DateType, () => DateTime.parse(1980 + "-01-01T10:00:00-00:00").toDate, _ shouldBe a [java.sql.Date]), // TODO date should be timestamp (if not supported by elastic natively)
+    ESColumnMetadata("salary", "DOUBLE", "salary" typed DoubleType, () => 0.15, _ shouldBe a[java.lang.Double])
+    //ESColumnMetadata("float", "FLOAT", "float" typed FloatType, () => 0.15, _ shouldBe a[java.lang.Float]), // TODO float not supported natively
+    //ESColumnMetadata("binary", "BINARY", "binary" typed BinaryType, () => Array(Byte.MaxValue, Byte.MinValue), x => x.isInstanceOf[Array[Byte]] shouldBe true) // TODO native and spark ko
+    //ESColumnMetadata("tinyint", "TINYINT", "tinyint" typed ByteType, () => Byte.MinValue, _ shouldBe a[java.lang.Byte]), // TODO native ko
+    //ESColumnMetadata("smallint", "SMALLINT", "smallint" typed ShortType, () => Short.MaxValue, _ shouldBe a[java.lang.Short]) // TODO native ko
+    // TODO study access to multi-field (example name with multiple fields: raw (not analyzed) and name spanish (analyzed with specific analyzer) ?
+    //ESColumnMetadata("subdocument", "STRUCT<field1: INT>", "subdocument"  inner ("field1" typed IntegerType), () =>  Map( "field1" -> 15), _ shouldBe a [Row]) // TODO native ko
+    // TODO study nested type => to enable flattening
+    // TODO complex structures => [[SharedXDContextTypesTest]]
+
+  )
+
+  override protected def saveTestData: Unit = for (a <- 1 to 1) {
+    client.get.execute {
+      index into Index / Type fields( dataTest.map( colMetadata => (colMetadata.fieldName,colMetadata.data())): _*)
+    }.await
+    client.get.execute {
+      flush index Index
+    }.await
+  }
+
+  override protected def terminateClient: Unit = client.get.close()
+
+  override protected def cleanTestData: Unit = cleanTestData(client.get, Index)
+
+  //Template steps: Override them
+  override protected def prepareClient: Option[ClientParams] = Try {
+    logInfo(s"Connection to elastic search, ElasticHost: $ElasticHost, ElasticNativePort:$ElasticNativePort, ElasticClusterName $ElasticClusterName")
+    val settings = ImmutableSettings.settingsBuilder().put("cluster.name", ElasticClusterName).build()
+    val elasticClient = ElasticClient.remote(settings, ElasticHost, ElasticNativePort)
+    createIndex(elasticClient, Index, typeMapping())
+    elasticClient
+  } toOption
+
+
+  override def sparkRegisterTableSQL: Seq[SparkTable] = super.sparkRegisterTableSQL :+
+    str2sparkTableDesc(
+      s"CREATE TEMPORARY TABLE $Type ( ${fieldAndSparkType() mkString "," })"
+    )
+
+
+  override val runningError: String = "ElasticSearch and Spark must be up and running"
+
+  def createIndex(elasticClient: ElasticClient, indexName:String, mappings:MappingDefinition): Unit ={
+    val command = Option(mappings).fold(create index indexName)(create index indexName mappings _)
+    elasticClient.execute {command}.await
+  }
+
+  def fieldAndSparkType(): Seq[String] = {
+    Seq( dataTest.map(colMetadata => s"${colMetadata.fieldName}  ${colMetadata.sparkSqlType}") : _*)
+  }
+
+  def typeMapping(): MappingDefinition ={
+    Type as(
+      dataTest.map(_.elasticType) :_*
+      )
+  }
+
+  def cleanTestData(elasticClient: ElasticClient, indexName:String): Unit = {
+    elasticClient.execute {
+      deleteIndex(indexName)
+    }
+  }
+
+}
+
+
+trait ElasticSearchDataTypesDefaultConstants extends ElasticSearchDefaultConstants{
+  private lazy val config = ConfigFactory.load()
+  override val Index = s"idxname${UUID.randomUUID.toString.replaceAll("-", "")}"
+  override val Type = s"typename${UUID.randomUUID.toString.replaceAll("-", "")}"
+
+}

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticDataTypesWithSharedContext.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticDataTypesWithSharedContext.scala
@@ -17,7 +17,7 @@ package com.stratio.crossdata.connector.elasticsearch
 
 import java.util.{GregorianCalendar, UUID}
 
-import com.sksamuel.elastic4s.ElasticClient
+import com.sksamuel.elastic4s.{ElasticClient, ElasticsearchClientUri}
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.mappings.FieldType._
 import com.sksamuel.elastic4s.mappings.{MappingDefinition, TypedFieldDefinition}
@@ -25,9 +25,9 @@ import com.stratio.common.utils.components.logger.impl.SparkLoggerComponent
 import com.typesafe.config.ConfigFactory
 import org.apache.spark.sql.crossdata.test.SharedXDContextWithDataTest
 import org.apache.spark.sql.crossdata.test.SharedXDContextWithDataTest.SparkTable
-import org.elasticsearch.common.settings.ImmutableSettings
+import org.elasticsearch.common.settings.Settings
 import org.scalatest.Suite
-
+import org.joda.time.DateTime
 import scala.util.Try
 
 
@@ -83,8 +83,8 @@ trait ElasticDataTypesWithSharedContext extends SharedXDContextWithDataTest with
   //Template steps: Override them
   override protected def prepareClient: Option[ClientParams] = Try {
     logInfo(s"Connection to elastic search, ElasticHost: $ElasticHost, ElasticNativePort:$ElasticNativePort, ElasticClusterName $ElasticClusterName")
-    val settings = ImmutableSettings.settingsBuilder().put("cluster.name", ElasticClusterName).build()
-    val elasticClient = ElasticClient.remote(settings, ElasticHost, ElasticNativePort)
+    val settings = Settings.settingsBuilder().put("cluster.name", ElasticClusterName).build()
+    val elasticClient = ElasticClient.transport(settings, ElasticsearchClientUri(ElasticHost, ElasticNativePort))
     createIndex(elasticClient, Index, typeMapping())
     elasticClient
   } toOption
@@ -108,7 +108,7 @@ trait ElasticDataTypesWithSharedContext extends SharedXDContextWithDataTest with
   }
 
   def typeMapping(): MappingDefinition ={
-    Type as(
+    mapping(Type) fields (
       dataTest.map(_.elasticType) :_*
       )
   }

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchNewTypesIT.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchNewTypesIT.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.crossdata.connector.elasticsearch
+
+import org.apache.spark.sql.crossdata.ExecutionType._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ElasticSearchNewTypesIT extends ElasticDataTypesWithSharedContext {
+
+  // TODO replace old test when values are checked
+  "A ElasticSearchQueryProcessor " should "Return types in correct format" in {
+    assumeEnvironmentIsUpAndRunning
+
+    val dataframe = sql(s"SELECT * FROM $Type where id = 1")
+
+    Seq( Spark, Native).foreach{ executionType =>
+
+      val rows = dataframe.collect(executionType)
+      //Expectations
+      rows should have length 1
+      val row = rows(0)
+
+      dataTest.zipWithIndex.foreach{ case (colMetadata, idx) =>
+        val field = row.get(idx)
+        colMetadata.typeValidation(field)
+      }
+    }
+
+    // TODO test values
+
+  }
+}


### PR DESCRIPTION
## Description

This PRs changes the behavior of `com.stratio.crossdata.connector.elasticsearch.DefaultSource` by adding types conversions in the `ElasticsearchXDRelation` value extractor (executed at each node).

Note that huge parts of the original elastic search datasource have been copied  into our code thus adding maintenance hazards as the data source development continues. This has been done this way because of the limitations raised by the author's use of access modifiers. 

### Testing
- [x] Unit tests
