### PR TITLE
Removed Jenkins' crossbuild as we are abandoning Scala 2.10 support

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -1,11 +1,3 @@
-CROSSBUILD:
-  - 'scala-2.10'
-  - 'scala-2.11'
-
-CROSSBUILDAT:
-  - 'scala-2.10'
-  - 'scala-2.11'
-  
 ITSERVICES:
   - SPARK:
       image: stratio/spark:1.6.1


### PR DESCRIPTION
This constraint comes from the fact that, soon, we'll be using Akka 2.4+ which is not binary compatible with Scala 2.10