### PR TITLE
Update elasticsearch-hadoop data source version to 2.4.0

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -4,9 +4,6 @@ CROSSBUILD:
 CROSSBUILDAT:
   - 'scala-2.11'
   
-CROSSBUILDAT:
-  - 'scala-2.11'
-  
 ITSERVICES:
   - SPARK:
       image: stratio/spark:1.6.1
@@ -67,7 +64,7 @@ ATSERVICES:
       image: elasticsearch:2.0.2
       sleep: 10
       env:
-     	 - ES_JAVA_OPTS="-Des.cluster.name=%%JUID -Des.network.host=%%OWNHOSTNAME"
+        - ES_JAVA_OPTS="-Des.cluster.name=%%JUID -Des.network.host=%%OWNHOSTNAME"
   - CASSANDRA:
       image: stratio/cassandra-lucene-index:2.2.5.3
       sleep: 10

--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -5,7 +5,6 @@ CROSSBUILDAT:
   - 'scala-2.11'
   
 CROSSBUILDAT:
-  - 'scala-2.10'
   - 'scala-2.11'
   
 ITSERVICES:
@@ -68,7 +67,7 @@ ATSERVICES:
       image: elasticsearch:2.0.2
       sleep: 10
       env:
-        - ES_JAVA_OPTS=-Des.cluster.name=%%JUID
+     	 - ES_JAVA_OPTS="-Des.cluster.name=%%JUID -Des.network.host=%%OWNHOSTNAME"
   - CASSANDRA:
       image: stratio/cassandra-lucene-index:2.2.5.3
       sleep: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ Only listing significant user-visible, not internal code cleanups and minor bug 
 
 ## 1.6.0 (upcoming)
 
-* Elasticsearch: support import tables without specifying a particular resource
+* Elasticsearch: 
+    * Support import tables without specifying a particular resource
+    * Adds BINARY, TINYINT, FLOAT types.
+    * Adds support for sub documents at Native side.
+    
 * Major Akka version upgrade to 2.4 (2.4.9), thus enabling putting the server behind HAProxy. 
 
 ## 1.5.0 (August 2016)

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -33,7 +33,7 @@
     <url>http://stratio.github.io/crossdata/</url>
 
     <properties>
-        <elastic.datasource.version>2.3.3</elastic.datasource.version>
+        <elastic.datasource.version>2.4.0</elastic.datasource.version>
         <elastic4s.version>2.0.1</elastic4s.version>
         <jackson.elastic.version>2.5.3</jackson.elastic.version>
     </properties>

--- a/elasticsearch/src/main/scala/org/elasticsearch/spark/sql/ElasticsearchXDRelation.scala
+++ b/elasticsearch/src/main/scala/org/elasticsearch/spark/sql/ElasticsearchXDRelation.scala
@@ -16,7 +16,6 @@
 package org.elasticsearch.spark.sql
 
 import java.sql.{Date, Timestamp}
-import javax.xml.bind.DatatypeConverter
 
 import com.stratio.crossdata.connector.NativeScan
 import com.stratio.crossdata.connector.elasticsearch.ElasticSearchQueryProcessor
@@ -26,16 +25,10 @@ import org.apache.spark.sql.catalyst.plans.logical.Limit
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SQLContext}
-import org.elasticsearch.hadoop.cfg.{ConfigurationOptions, InternalConfigurationOptions}
 import org.elasticsearch.hadoop.rest.RestService.PartitionDefinition
-import org.elasticsearch.hadoop.serialization.json.JacksonJsonGenerator
-import org.elasticsearch.hadoop.util.{FastByteArrayOutputStream, IOUtils, StringUtils}
 import org.elasticsearch.spark.rdd.EsPartition
 
 import scala.collection.mutable
-import scala.collection.mutable.LinkedHashSet
-
-import java.util.{Date => UDate, Calendar, Locale}
 
 class ScalaXDEsRowRDDIterator(
                                context: TaskContext,
@@ -88,254 +81,34 @@ class ScalaXDEsRowRDD(
 class ElasticsearchXDRelation(parameters: Map[String, String], sqlContext: SQLContext, userSchema: Option[StructType] = None)
   extends ElasticsearchRelation(parameters, sqlContext, userSchema) with NativeScan with Logging {
 
-  private object CopiedCode {
 
-    def isClass(obj: Any, className: String) = {
-    className.equals(obj.getClass().getName())
-  }
-
-    def extract(value: Any): String = {
-    extract(value, true, false)
-  }
-
-    def extractAsJsonArray(value: Any): String = { extract(value, true, true) }
-
-    def extractMatchArray(attribute: String, ar: Array[Any]): String = {
-    // use a set to avoid duplicate values
-    // especially since Spark conversion might turn each user param into null
-    val numbers = LinkedHashSet.empty[AnyRef]
-    val strings = LinkedHashSet.empty[AnyRef]
-
-    // move numbers into a separate list for a terms query combined with a bool
-    for (i <- ar) i.asInstanceOf[AnyRef] match {
-      case null => // ignore
-      case n: Number => numbers += extract(i, false, false)
-      case _ => strings += extract(i, false, false)
-    }
-
-    if (numbers.isEmpty) {
-      if (strings.isEmpty) {
-        return StringUtils.EMPTY
-      }
-      return s"""{"query":{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}}"""
-      //s"""{"query":{"$attribute":${strings.mkString("\"", " ", "\"")}}}"""
-    }
-    else {
-      // translate the numbers into a terms query
-      val str =
-      s"""{"terms":{"$attribute":${numbers.mkString("[", ",", "]")}}}"""
-      if (strings.isEmpty) return str
-      // if needed, add the strings as a match query
-      else return str + s""",{"query":{"match":{"$attribute":${strings.mkString("\"", " ", "\"")}}}}"""
-    }
-  }
-
-    def extract(value: Any, inJsonFormat: Boolean, asJsonArray: Boolean): String = {
-    // common-case implies primitives and String so try these before using the full-blown ValueWriter
-    value match {
-      case null => "null"
-      case u: Unit => "null"
-      case b: Boolean => b.toString
-      case by: Byte => by.toString
-      case s: Short => s.toString
-      case i: Int => i.toString
-      case l: Long => l.toString
-      case f: Float => f.toString
-      case d: Double => d.toString
-      case bd: BigDecimal => bd.toString
-      case _: Char |
-           _: String |
-           _: Array[Byte] => if (inJsonFormat) StringUtils.toJsonString(value.toString) else value.toString()
-      // handle Timestamp also
-      case dt: UDate => {
-        val cal = Calendar.getInstance()
-        cal.setTime(dt)
-        val str = DatatypeConverter.printDateTime(cal)
-        if (inJsonFormat) StringUtils.toJsonString(str) else str
-      }
-      case ar: Array[Any] =>
-        if (asJsonArray) (for (i <- ar) yield extract(i, true, false)).distinct.mkString("[", ",", "]")
-        else (for (i <- ar) yield extract(i, false, false)).distinct.mkString("\"", " ", "\"")
-      // new in Spark 1.4
-      case utf if (isClass(utf, "org.apache.spark.sql.types.UTF8String")
-        // new in Spark 1.5
-        || isClass(utf, "org.apache.spark.unsafe.types.UTF8String"))
-      => if (inJsonFormat) StringUtils.toJsonString(utf.toString()) else utf.toString()
-      case a: AnyRef => {
-        val storage = new FastByteArrayOutputStream()
-        val generator = new JacksonJsonGenerator(storage)
-        valueWriter.write(a, generator)
-        generator.flush()
-        generator.close()
-        storage.toString()
-      }
-    }
-  }
-
-    // string interpolation FTW
-    def translateFilter(filter: Filter, strictPushDown: Boolean): String = {
-    // the pushdown can be strict - i.e. use only filters and thus match the value exactly (works with non-analyzed)
-    // or non-strict meaning queries will be used instead that is the filters will be analyzed as well
-    filter match {
-
-      case EqualTo(attribute, value) => {
-        // if we get a null, translate it into a missing query (we're extra careful - Spark should translate the equals into isMissing anyway)
-        if (value == null || value == None || value == Unit) {
-          return s"""{"missing":{"field":"$attribute"}}"""
-        }
-
-        if (strictPushDown)
-          s"""{"term":{"$attribute":${extract(value)}}}"""
-        else
-          s"""{"query":{"match":{"$attribute":${extract(value)}}}}"""
-      }
-      case GreaterThan(attribute, value) => s"""{"range":{"$attribute":{"gt" :${extract(value)}}}}"""
-      case GreaterThanOrEqual(attribute, value) => s"""{"range":{"$attribute":{"gte":${extract(value)}}}}"""
-      case LessThan(attribute, value) => s"""{"range":{"$attribute":{"lt" :${extract(value)}}}}"""
-      case LessThanOrEqual(attribute, value) => s"""{"range":{"$attribute":{"lte":${extract(value)}}}}"""
-      case In(attribute, values) => {
-        // when dealing with mixed types (strings and numbers) Spark converts the Strings to null (gets confused by the type field)
-        // this leads to incorrect query DSL hence why nulls are filtered
-        val filtered = values filter (_ != null)
-        if (filtered.isEmpty) {
-          return ""
-        }
-
-        // further more, match query only makes sense with String types so for other types apply a terms query (aka strictPushDown)
-        val attrType = lazySchema.struct(attribute).dataType
-        val isStrictType = attrType match {
-          case DateType |
-               TimestampType => true
-          case _ => false
-        }
-
-        if (!strictPushDown && isStrictType) {
-          if (Utils.LOGGER.isDebugEnabled()) {
-            Utils.LOGGER.debug(s"Attribute $attribute type $attrType not suitable for match query; using terms (strict) instead")
-          }
-        }
-
-        if (strictPushDown || isStrictType)
-          s"""{"terms":{"$attribute":${extractAsJsonArray(filtered)}}}"""
-        else
-          s"""{"or":{"filters":[${extractMatchArray(attribute, filtered)}]}}"""
-      }
-      case IsNull(attribute) => s"""{"missing":{"field":"$attribute"}}"""
-      case IsNotNull(attribute) => s"""{"exists":{"field":"$attribute"}}"""
-      case And(left, right) => s"""{"and":{"filters":[${translateFilter(left, strictPushDown)}, ${translateFilter(right, strictPushDown)}]}}"""
-      case Or(left, right) => s"""{"or":{"filters":[${translateFilter(left, strictPushDown)}, ${translateFilter(right, strictPushDown)}]}}"""
-      case Not(filterToNeg) => s"""{"not":{"filter":${translateFilter(filterToNeg, strictPushDown)}}}"""
-
-      // the filter below are available only from Spark 1.3.1 (not 1.3.0)
-
-      //
-      // String Filter notes:
-      //
-      // the DSL will be quite slow (linear to the number of terms in the index) but there's no easy way around them
-      // we could use regexp filter however it's a bit overkill and there are plenty of chars to escape
-      // s"""{"regexp":{"$attribute":"$value.*"}}"""
-      // as an alternative we could use a query string but still, the analyzed / non-analyzed is there as the DSL is slightly more complicated
-      // s"""{"query":{"query_string":{"default_field":"$attribute","query":"$value*"}}}"""
-      // instead wildcard query is used, with the value lowercased (to match analyzed fields)
-
-      case f: Product if isClass(f, "org.apache.spark.sql.sources.StringStartsWith") => {
-        var arg = f.productElement(1).toString()
-        if (!strictPushDown) {
-          arg = arg.toLowerCase(Locale.ROOT)
-        }
-        s"""{"query":{"wildcard":{"${f.productElement(0)}":"$arg*"}}}"""
-      }
-
-      case f: Product if isClass(f, "org.apache.spark.sql.sources.StringEndsWith") => {
-        var arg = f.productElement(1).toString()
-        if (!strictPushDown) {
-          arg = arg.toLowerCase(Locale.ROOT)
-        }
-        s"""{"query":{"wildcard":{"${f.productElement(0)}":"*$arg"}}}"""
-      }
-
-      case f: Product if isClass(f, "org.apache.spark.sql.sources.StringContains") => {
-        var arg = f.productElement(1).toString()
-        if (!strictPushDown) {
-          arg = arg.toLowerCase(Locale.ROOT)
-        }
-        s"""{"query":{"wildcard":{"${f.productElement(0)}":"*$arg*"}}}"""
-      }
-
-      // the filters below are available only from Spark 1.5.0
-
-      case f: Product if isClass(f, "org.apache.spark.sql.sources.EqualNullSafe") => {
-        var arg = extract(f.productElement(1))
-        if (strictPushDown)
-          s"""{"term":{"${f.productElement(0)}":$arg}}"""
-        else
-          s"""{"query":{"match":{"${f.productElement(0)}":$arg}}}"""
-      }
-
-      case _ => ""
-    }
-  }
-
-    def createDSLFromFilters(filters: Array[Filter], strictPushDown: Boolean) = {
-      filters.map(filter => translateFilter(filter, strictPushDown)).filter(query => StringUtils.hasText(query))
-    }
-
-  }
-
-  // PrunedFilteredScan
   override def buildScan(requiredColumns: Array[String], filters: Array[Filter]) = {
-    import CopiedCode._
-    val paramWithScan = mutable.LinkedHashMap[String, String]() ++ parameters
-    paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_TARGET_FIELDS ->
-      StringUtils.concatenate(requiredColumns.asInstanceOf[Array[Object]], StringUtils.DEFAULT_DELIMITER))
-
-    // scroll fields only apply to source fields; handle metadata separately
-    if (cfg.getReadMetadata) {
-      val metadata = cfg.getReadMetadataField
-      // if metadata is not selected, don't ask for it
-      if (!requiredColumns.contains(metadata)) {
-        paramWithScan += (ConfigurationOptions.ES_READ_METADATA -> false.toString())
-      }
-    }
-
-    if (filters != null && filters.size > 0) {
-      if (Utils.isPushDown(cfg)) {
-        if (Utils.LOGGER.isDebugEnabled()) {
-          Utils.LOGGER.debug(s"Pushing down filters ${filters.mkString("[", ",", "]")}")
-        }
-        val filterString = createDSLFromFilters(filters, Utils.isPushDownStrict(cfg))
-
-        if (Utils.LOGGER.isTraceEnabled()) {
-          Utils.LOGGER.trace(s"Transformed filters into DSL ${filterString.mkString("[", ",", "]")}")
-        }
-        paramWithScan += (InternalConfigurationOptions.INTERNAL_ES_QUERY_FILTERS -> IOUtils.serializeToBase64(filterString))
-      }
-      else {
-        if (Utils.LOGGER.isTraceEnabled()) {
-          Utils.LOGGER.trace("Push-down is disabled; ignoring Spark filters...")
-        }
-      }
-    }
-
-    new ScalaXDEsRowRDD(sqlContext.sparkContext, paramWithScan, lazySchema, userSchema)
-  }
-
-  /* TODO: Removed copied code (from ES connector) and uncomment this method when the next version of the connector
-      gets released.
-     */
-  /*override def buildScan(requiredColumns: Array[String], filters: Array[Filter]) = {
     val rdd = super.buildScan(requiredColumns, filters)
     userSchema map { uschema: StructType =>
       val name2expectedType: Map[String, DataType] = uschema.map(field => field.name -> field.dataType).toMap
-      //lazySchema.struct map
+
       val transformations: Map[String, Any => Any] = name2expectedType.collect {
         case (k, _: DateType) => k -> ((timestamp: Any) => new Date(timestamp.asInstanceOf[Timestamp].getTime))
       }
       rdd.map {
-        case esRow: ScalaEsRow => esRow : Row //PERFORM TRANSFORMATIONS HERE
+        case esRow: ScalaEsRow =>
+          lazy val newRow = esRow.copy()
+          var hasChanges = false
+
+          for(
+            ((value, name), idx) <- (esRow.values zip esRow.rowOrder) zipWithIndex;
+            trans <- transformations.get(name)
+          ) {
+            hasChanges = true
+            newRow.values.update(idx, trans(value))
+          }
+
+          (if(hasChanges) newRow else esRow) : Row
+
+        case other: Row => other
       }
     } getOrElse rdd
-  }*/
+  }
 
   /**
    * Build and Execute a NativeScan for the [[LogicalPlan]] provided.

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticDataTypesWithSharedContext.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticDataTypesWithSharedContext.scala
@@ -61,10 +61,8 @@ trait ElasticDataTypesWithSharedContext extends SharedXDContextWithDataTest with
     ESColumnMetadata("salary", "DOUBLE", "salary" typed DoubleType, () => 0.15, _ shouldBe a[java.lang.Double]),
     ESColumnMetadata("timecol", "TIMESTAMP", "timecol" typed DateType, () => new java.sql.Timestamp(new GregorianCalendar(1970, 0, 1, 0, 0, 0).getTimeInMillis), _ shouldBe a[java.sql.Timestamp]),
     ESColumnMetadata("float", "FLOAT", "float" typed FloatType, () => 0.15, _ shouldBe a[java.lang.Float]),
-    /* ESColumnMetadata("binary", "BINARY", "binary" typed BinaryType, () => "YWE=".getBytes, x => x
-      .isInstanceOf[Array[Byte]] shouldBe true), TODO: KO Spark, not critical pending datasource fix
-      https://github.com/elastic/elasticsearch-hadoop/pull/834
-      */
+    ESColumnMetadata("binary", "BINARY", "binary" typed BinaryType, () => "YWE=".getBytes, x => x
+      .isInstanceOf[Array[Byte]] shouldBe true),
     ESColumnMetadata("tinyint", "TINYINT", "tinyint" typed ByteType, () => Byte.MinValue, _ shouldBe a[java.lang.Byte]),
     ESColumnMetadata("smallint", "SMALLINT", "smallint" typed ShortType, () => Short.MaxValue, _ shouldBe a[java.lang.Short]),
     ESColumnMetadata("subdocument", "STRUCT<field1: INT>", "subdocument"  inner ("field1" typed IntegerType), () => Map( "field1" -> 15), _ shouldBe a [Row]),

--- a/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchNewTypesIT.scala
+++ b/elasticsearch/src/test/scala/com/stratio/crossdata/connector/elasticsearch/ElasticSearchNewTypesIT.scala
@@ -15,6 +15,7 @@
  */
 package com.stratio.crossdata.connector.elasticsearch
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.crossdata.ExecutionType._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -22,26 +23,36 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class ElasticSearchNewTypesIT extends ElasticDataTypesWithSharedContext {
 
-  // TODO replace old test when values are checked
-  "A ElasticSearchQueryProcessor " should "Return types in correct format" in {
+  var row: Row = _
+
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
     assumeEnvironmentIsUpAndRunning
-
     val dataframe = sql(s"SELECT * FROM $Type where id = 1")
-
-    Seq( Spark, Native).foreach{ executionType =>
+    Seq(Spark, Native).foreach { executionType =>
 
       val rows = dataframe.collect(executionType)
       //Expectations
       rows should have length 1
-      val row = rows(0)
-
-      dataTest.zipWithIndex.foreach{ case (colMetadata, idx) =>
-        val field = row.get(idx)
-        colMetadata.typeValidation(field)
-      }
+      row = rows(0)
     }
+  }
+
+
+  // TODO replace old test when values are checked
+
+
+      dataTest.zipWithIndex.foreach { case (colMetadata, idx) =>
+        "A ElasticSearchQueryProcessor " should
+          s"Return ${colMetadata.sparkSqlType} type in correct format (test column `${colMetadata.fieldName}`)" in {
+          val field = row.get(idx)
+          colMetadata.typeValidation(field)
+        }
+      }
+
 
     // TODO test values
 
-  }
+
+
 }


### PR DESCRIPTION
## Description

New changes at the elastic data source allow us to get rid off many copy-paste lines within Crossdata connector. 

It also adds a bug fix enabling the BINARY field type.

### Testing
- [x] Unit tests have been updated to include the recently supported type.

### Documentation
- [x] Changelog update
