### PR TITLE
Delete dependency with the akka protobuf due to akka upgrade

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -111,7 +111,6 @@
                                     <include>com.google.guava:guava</include>
                                     <include>io.netty:netty-all</include>
                                     <include>io.netty:netty</include>
-                                    <include>com.google.protobuf:protobuf-java</include>
                                     <include>org.slf4j:slf4j-api</include>
                                     <include>org.slf4j:slf4j-log4j12</include>
                                     <include>log4j:log4j:jar</include>
@@ -289,7 +288,6 @@
                                     <include>com.google.guava:guava</include>
                                     <include>io.netty:netty-all</include>
                                     <include>io.netty:netty</include>
-                                    <include>com.google.protobuf:protobuf-java</include>
                                     <include>log4j:log4j:jar</include>
                                     <include>org.scala-lang:scala-library</include>
                                     <include>org.scala-lang:scala-reflect</include>


### PR DESCRIPTION
## Description
Delete dependency with the akka protobuf due to akka upgrade. Not necessary anymore.

### Testing
- [ ] Unit, integration tests

### Documentation
- [ ] Changelog update
- [ ] Documentation link

