### PR TITLE
[CROSSDATA-646] Crossdata as runs as an application instead as an Upstart service within docker.

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -118,6 +118,10 @@ sed -i "s|crossdata-server.config.spark.driver.memory.*|crossdata-server.config.
 sed -i "s|crossdata-server.config.spark.executor.memory.*|crossdata-server.config.spark.executor.memory = ${XD_EXECUTOR_MEMORY:=512M}|" /etc/sds/crossdata/server/server-application.conf
 sed -i "s|crossdata-server.config.spark.cores.max.*|crossdata-server.config.spark.cores.max = ${XD_CORES:=4}|" /etc/sds/crossdata/server/server-application.conf
 
-/etc/init.d/crossdata start
-
-tail -F /var/log/sds/crossdata/crossdata.log
+if [ "$SERVER_MODE" == "debug" ]; then
+    # In this mode, crossdata will be launched as a service within the docker container.
+    /etc/init.d/crossdata start 
+    tail -F /var/log/sds/crossdata/crossdata.log
+else
+    /opt/sds/crossdata/bin/server.sh
+fi;


### PR DESCRIPTION
## Description

After merging this PR Crossdata will be launched as an application within the docker, not as an INIT daemon. That makes its output to be correctly redirected to cluster managers as well as the docker container be stopped if the server crashes.

If the docker is run with the option `-e SERVER_MODE=debug` it will launch Crossdata as a service within the docker container, that is, as before the PR was merged.

### Testing
- [x] Manual tests