### PR TITLE
[CROSSDATA-649] Network params docker entry point

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -115,6 +115,14 @@ else
     fi
 fi
 
+if [ -n "$XD_EXTERNAL_IP" ]; then
+    NAMEADDR="$(hostname -i)"
+    if [ -n "$HAPROXY_SERVER_INTERNAL_ADDRESS" ]; then
+	NAMEADDR=$HAPROXY_SERVER_INTERNAL_ADDRESS
+    fi
+    echo -e "$NAMEADDR\t$XD_EXTERNAL_IP" >> /etc/hosts
+fi
+
 if [ "$SERVER_MODE" == "debug" ]; then
     # In this mode, crossdata will be launched as a service within the docker container.
     /etc/init.d/crossdata start 


### PR DESCRIPTION
## Description

The docker entry point now also reacts to the presence of XD_EXTERNAL_IP by adding an alias from its values to the docker exposed ip at /etc/hosts.

It is also sensitive to the variable HAPROXY_SERVER_INTERNAL_ADDRESS. If present, the aliased IP will be its value instead of the docker exposed IP thus allowing HA Proxy loop.