### PR TITLE
Bug fix: Unwrapped error result when the session is closed

### DIFF
--- a/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/actors/ServerActor.scala
@@ -115,7 +115,10 @@ class ServerActor(cluster: Cluster, sessionProvider: XDSessionProvider)
 
         case Failure(error) =>
           logger.warn(s"Received message with an unknown sessionId $id", error)
-          sender ! ErrorSQLResult(s"Unable to recover the session ${session.id}. Cause: ${error.getMessage}")
+          sender ! SQLReply(
+            sqlCommand.requestId,
+            ErrorSQLResult(s"Unable to recover the session ${session.id}. Cause: ${error.getMessage}")
+          )
       }
 
 


### PR DESCRIPTION
## Description

When a session is not found and this way an error result is returned, it should be wrapped by a SQLReplay object.