### PR TITLE
serversUp method available in the Java Driver

### DIFF
--- a/driver/src/main/scala/com/stratio/crossdata/driver/JavaDriver.scala
+++ b/driver/src/main/scala/com/stratio/crossdata/driver/JavaDriver.scala
@@ -23,7 +23,7 @@ import com.stratio.crossdata.driver.session.Authentication
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters.
+import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 

--- a/driver/src/main/scala/com/stratio/crossdata/driver/JavaDriver.scala
+++ b/driver/src/main/scala/com/stratio/crossdata/driver/JavaDriver.scala
@@ -15,6 +15,7 @@
  */
 package com.stratio.crossdata.driver
 
+import akka.actor.Address
 import com.stratio.crossdata.common.result.SQLResult
 import com.stratio.crossdata.driver.config.DriverConf
 import com.stratio.crossdata.driver.metadata.{FieldMetadata, JavaTableName}
@@ -22,7 +23,9 @@ import com.stratio.crossdata.driver.session.Authentication
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConversions._
-import scala.concurrent.duration.Duration
+import scala.collection.JavaConverters.
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 
 class JavaDriver private(driverConf: DriverConf,
@@ -102,6 +105,14 @@ class JavaDriver private(driverConf: DriverConf,
    */
   def isClusterAlive(): Boolean =
     scalaDriver.isClusterAlive()
+
+  /**
+    * Get a list of the nodes forming the Crossdata cluster.
+    *
+    * @since 1.7
+    * @return list of addresses of servers running.
+    */
+  def serversUp(): java.util.List[Address]  = Await.result(scalaDriver.serversUp(), 10 seconds).asJava
 
   def closeSession(): Unit =
     scalaDriver.closeSession()


### PR DESCRIPTION
## Description
This PR adds the method serversUp to the Java Driver in order to have information about the nodes forming the Crossdata cluster.

