### PR TITLE
[CROSSDATA-647] Fix microstrategy problem with create table as select

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalyst/execution/ddl.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalyst/execution/ddl.scala
@@ -22,7 +22,7 @@ import com.stratio.crossdata.connector.{TableInventory, TableManipulation}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Subquery}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Subquery}
 import org.apache.spark.sql.crossdata.XDContext
 import org.apache.spark.sql.crossdata.catalog.XDCatalog._
 import org.apache.spark.sql.crossdata.catalog.interfaces.XDCatalogCommon._
@@ -148,7 +148,18 @@ private[crossdata] case class ImportTablesUsingWithOptions(datasource: String, o
 private[crossdata] case class DropTable(tableIdentifier: TableIdentifier) extends RunnableCommand {
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
-    sqlContext.catalog.dropTable(tableIdentifier)
+
+    if(sqlContext.catalog.tableExists(tableIdentifier)){
+      sqlContext.catalog.lookupRelation(tableIdentifier) match {
+        case Subquery(_, Project(_,_)) =>
+          sqlContext.catalog.dropView(tableIdentifier)
+        case _ =>
+          sqlContext.catalog.dropTable(tableIdentifier)
+      }
+    } else {
+      sqlContext.catalog.dropTable(tableIdentifier) //Force launching exception from catalog
+    }
+
     Seq.empty
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalyst/parser/XDDdlParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalyst/parser/XDDdlParser.scala
@@ -143,7 +143,7 @@ class XDDdlParser(parseQuery: String => LogicalPlan, xDContext: XDContext) exten
     }
 
   protected lazy val createView: Parser[LogicalPlan] = {
-    (CREATE ~> TEMPORARY.? <~ VIEW) ~ tableIdentifier ~ schemaValues.? ~ (AS ~> restInput) ^^ {
+    (CREATE ~> TEMPORARY.? <~ (VIEW | TABLE)) ~ tableIdentifier ~ schemaValues.? ~ (AS ~> restInput) ^^ {
       case temp ~ viewIdentifier ~ cols ~ query =>
         if (temp.isDefined)
           CreateTempView(viewIdentifier, parseQuery(query), query)

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/DropTableIT.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/DropTableIT.scala
@@ -56,4 +56,24 @@ class DropTableIT extends SharedXDContextTest {
     sql(s"DROP TABLE $DatabaseName.$TableName")
     _xdContext.catalog.tableExists(TableIdentifier(TableName, Some(DatabaseName))) shouldBe false
   }
+
+
+  it should "remove a view when table doesn't exists but view with its name exists in the catalog" in {
+    val viewName = s"tmpTableDrop$TableName"
+
+    _xdContext.catalog.persistTableMetadata(CrossdataTable(TableIdentifier(TableName, None).normalize, Some(Schema), DatasourceName, opts = Map("path" -> "fakepath")))
+    _xdContext.catalog.tableExists(TableIdentifier(TableName)) shouldBe true
+    _xdContext.catalog.tableExists(TableIdentifier(viewName)) shouldBe false
+
+    sql(s"CREATE TABLE $viewName AS SELECT col FROM $TableName")
+    _xdContext.catalog.tableExists(TableIdentifier(viewName)) shouldBe true
+
+    sql(s"DROP TABLE $viewName")
+    _xdContext.catalog.tableExists(TableIdentifier(viewName)) shouldBe false
+
+    sql(s"DROP TABLE $TableName")
+    _xdContext.catalog.tableExists(TableIdentifier(TableName)) shouldBe false
+  }
+
+
 }

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/ViewsIT.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/ViewsIT.scala
@@ -51,6 +51,34 @@ class ViewsIT extends SharedXDContextTest {
 
   }
 
+  "Create temp table" should "return a XDDataFrame when executing a SQL query" in {
+
+    val sqlContext = _xdContext
+    import sqlContext.implicits._
+
+    val df  = sqlContext.sparkContext.parallelize(1 to 5).toDF
+    df.registerTempTable("person")
+    sql("CREATE TEMPORARY TABLE vn AS SELECT * FROM person WHERE _1 < 3")
+
+    val dataframe = xdContext.sql("SELECT * FROM vn")
+
+    dataframe shouldBe a[XDDataFrame]
+    dataframe.collect() should have length 2
+  }
+
+  // TODO When we can add views to Zookeeper catalog, Views' test should be moved to GenericCatalogTests in order to test the specific implementations.
+  "Create table as select" should "persist a view in the catalog only with persisted tables" in {
+    val sqlContext = _xdContext
+    import sqlContext.implicits._
+
+    val df = sqlContext.sparkContext.parallelize(1 to 5).toDF
+    a[RuntimeException] shouldBe thrownBy {
+      df.registerTempTable("person")
+      sql("CREATE TABLE persistedview AS SELECT * FROM person WHERE _1 < 3")
+    }
+
+  }
+
 
 
 }

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParserSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/execution/datasources/XDDdlParserSpec.scala
@@ -227,6 +227,19 @@ class XDDdlParserSpec extends BaseXDTest with MockitoSugar{
 
   }
 
+  it should "successfully parse a CREATE TABLE into a CreateView RunnableCommand" in {
+
+    val sentence = "CREATE TABLE vn AS SELECT * FROM tn"
+    val logicalPlan = parser.parse(sentence)
+    logicalPlan shouldBe a [CreateView]
+    logicalPlan match {
+      case CreateView(tableIdent, lPlan, sqlView) =>
+        tableIdent shouldBe TableIdentifier("vn")
+        sqlView.trim shouldBe  "SELECT * FROM tn"
+    }
+
+  }
+
   it should "successfully parse a CREATE TEMPORARY VIEW into a CreateTempView RunnableCommand" in {
 
     val sourceSentence = "SELECT * FROM tn"
@@ -241,10 +254,38 @@ class XDDdlParserSpec extends BaseXDTest with MockitoSugar{
 
   }
 
+  it should "successfully parse a CREATE TEMPORARY TABLE into a CreateTempView RunnableCommand" in {
+
+    val sourceSentence = "SELECT * FROM tn"
+    val sentence = s"CREATE TEMPORARY TABLE vn AS $sourceSentence"
+    val logicalPlan = parser.parse(sentence)
+    logicalPlan shouldBe a [CreateTempView]
+    logicalPlan match {
+      case CreateTempView(tableIdent, lPlan, sql) =>
+        tableIdent shouldBe TableIdentifier("vn")
+        sql.map(_.trim) shouldBe Some(sourceSentence)
+    }
+
+  }
+
   it should "successfully parse a CREATE VIEW(...) into a CreateView RunnableCommand" in {
 
     val sourceSentence = "SELECT * FROM tn"
     val sentence = s"CREATE VIEW rareView(airport) AS $sourceSentence"
+    val logicalPlan = parser.parse(sentence)
+    logicalPlan shouldBe a [CreateView]
+    logicalPlan match {
+      case CreateView(tableIdent, lPlan, sql) =>
+        tableIdent shouldBe TableIdentifier("rareView")
+        sql.trim shouldBe sourceSentence
+    }
+
+  }
+
+  it should "successfully parse a CREATE TABLE(...) into a CreateView RunnableCommand" in {
+
+    val sourceSentence = "SELECT * FROM tn"
+    val sentence = s"CREATE TABLE rareView(airport) AS $sourceSentence"
     val logicalPlan = parser.parse(sentence)
     logicalPlan shouldBe a [CreateView]
     logicalPlan match {


### PR DESCRIPTION
## Description
Microstrategy doesn't support create table using as select, so if a query select table as query comes, It will have the same behaviour as a view.

### Testing
- [ ] Unit, integration tests

### Documentation
- [ ] Changelog update
- [ ] Documentation link
