### PR TITLE
Disabled TCP by default

### DIFF
--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -13,6 +13,8 @@ crossdata-server.external.config.filename = ${?CROSSDATA_SERVER_EXTERNAL_CONFIG_
 #                              #
 ################################
 # crossdata-server.akka.daemonic = on
+crossdata-server.config.cluster-client.enabled = false
+crossdata-server.config.cluster-client.enabled = ${?CROSSDATA_SERVER_CONFIG_CLUSTERCLIENT_ENABLE}
 crossdata-server.akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
 crossdata-server.akka.extensions = ["akka.cluster.pubsub.DistributedPubSub"]
 crossdata-server.akka.remote.netty.tcp.hostname = "127.0.0.1"

--- a/server/src/main/scala/com/stratio/crossdata/server/CrossdataServer.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/CrossdataServer.scala
@@ -133,11 +133,14 @@ class CrossdataServer(progrConfig: Option[Config] = None) extends ServiceDiscove
         actorName)
 
       val clientMonitor = actorSystem.actorOf(KeepAliveMaster.props(serverActor), "client-monitor")
-      ClusterClientReceptionist(actorSystem).registerService(clientMonitor)
-
       val resourceManagerActor = actorSystem.actorOf(ResourceManagerActor.props(Cluster(actorSystem), sessionProvider))
-      ClusterClientReceptionist(actorSystem).registerService(serverActor)
-      ClusterClientReceptionist(actorSystem).registerService(resourceManagerActor)
+
+      //Enable only if cluster client is enabled
+      if(serverConfig.getBoolean(ServerConfig.ClusterClientEnabled)){
+        ClusterClientReceptionist(actorSystem).registerService(clientMonitor)
+        ClusterClientReceptionist(actorSystem).registerService(serverActor)
+        ClusterClientReceptionist(actorSystem).registerService(resourceManagerActor)
+      }
 
       implicit val httpSystem = actorSystem
       implicit val materializer = ActorMaterializer()

--- a/server/src/main/scala/com/stratio/crossdata/server/config/ServerConfig.scala
+++ b/server/src/main/scala/com/stratio/crossdata/server/config/ServerConfig.scala
@@ -31,6 +31,9 @@ object ServerConfig {
   val ServerBasicConfig = "server-reference.conf"
   val ParentConfigName = "crossdata-server"
 
+  //Cluster client enabled
+  val ClusterClientEnabled = "config.cluster-client.enabled"
+
 
   val SparkSqlConfigPrefix = CoreConfig.SparkSqlConfigPrefix
 

--- a/testsIT/src/test/resources/server-application.conf
+++ b/testsIT/src/test/resources/server-application.conf
@@ -3,7 +3,7 @@
 #      Main config options     #
 #                              #
 ################################
-#crossdata-server.config.cluster-client.enabled = false
+crossdata-server.config.cluster-client.enabled = true
 #crossdata-server.akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
 #crossdata-server.akka.extensions = ["akka.contrib.pattern.ClusterReceptionistExtension"]
 #crossdata-server.akka.remote.netty.tcp.hostname = "127.0.0.1"


### PR DESCRIPTION
## Description
Disabled ClusterClient(TCP) by default. If you want to enable Cluster client set:

crossdata-server.config.cluster-client.enabled = true


### Testing
- [ ] Unit, integration tests

### Documentation
- [ ] Changelog update
- [ ] Documentation link

