### PR TITLE
RowSerializer: Safe guard against double types with Decimal schema tags

### DIFF
--- a/common/src/main/scala/com/stratio/crossdata/common/serializers/RowSerializer.scala
+++ b/common/src/main/scala/com/stratio/crossdata/common/serializers/RowSerializer.scala
@@ -95,6 +95,8 @@ case class RowSerializer(providedSchema: StructType) extends Serializer[Row] {
       case (DoubleType, v: Double) => JDouble(v)
       case (LongType, v: Long) => JInt(v)
       case (_: DecimalType, v: Decimal) => JDecimal(v.toBigDecimal)
+      case (_: DecimalType, v: Double) => JDecimal(BigDecimal(v))
+      case (_: DecimalType, v: Float) => JDecimal(BigDecimal(v))
       case (ByteType, v: Byte) => JInt(v.toInt)
       case (BinaryType, v: Array[Byte]) => JString(new String(v))
       case (BooleanType, v: Boolean) => JBool(v)


### PR DESCRIPTION
## Description

Spark inferences a PARQUET double column schema type as a DecimalType column when it should be Double. The serializer didn't expect this behavior and this PR adds safeguards to avoid failures.

### Testing
- [x] Unit, integration tests
