### PR TITLE
[CROSSDATA-883] XDSessionProvider: Code simplification, session factory (for provided users) & session id.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDDatasetFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDDatasetFunctions.scala
@@ -30,7 +30,6 @@ import scala.collection.mutable.BufferLike
 import scala.collection.{GenTraversableOnce, immutable, mutable}
 import scala.reflect.ClassTag
 
-
 trait XDDatasetFunctions {
 
   implicit def dataset2xddataset[T : ClassTag](ds: Dataset[T]): XDDataset[T] = new XDDataset[T](ds)
@@ -104,8 +103,6 @@ trait XDDatasetFunctions {
   class XDDataFrame(dataset: Dataset[Row]) {
 
     def flattenedCollect(): Array[Row] = {
-
-      val a = dataset
 
       def flattenProjectedColumns(exp: Expression, prev: List[String] = Nil): (List[String], Boolean) = exp match {
         case GetStructField(child, _, Some(fieldName))  =>

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDSession.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDSession.scala
@@ -198,19 +198,20 @@ object XDSession {
     * Builder for [[XDSession]].
     */
   class Builder extends SparkSessionBuilder {
+
     private[this] val options = new scala.collection.mutable.HashMap[String, String]
     private[this] var userSuppliedContext: Option[SparkContext] = None
 
-    override def config(key: String, value: String): SparkSessionBuilder = synchronized {
+    override def config(key: String, value: String): Builder = synchronized {
       options += key -> value
       this
     }
 
-    override def config(key: String, value: Long): SparkSessionBuilder = config(key, value)
-    override def config(key: String, value: Double): SparkSessionBuilder = config(key, value)
-    override def config(key: String, value: Boolean): SparkSessionBuilder = config(key, value)
+    override def config(key: String, value: Long): Builder = config(key, value)
+    override def config(key: String, value: Double): Builder = config(key, value)
+    override def config(key: String, value: Boolean): Builder = config(key, value)
 
-    override def config(conf: SparkConf): SparkSessionBuilder = synchronized {
+    override def config(conf: SparkConf): Builder = synchronized {
       conf.getAll.foreach { case (k, v) => options += k -> v }
       this
     }
@@ -235,7 +236,7 @@ object XDSession {
       *
       * @since 2.0.0
       */
-    def getOrCreate(userId: String): SparkSession = synchronized { // TODO session => one foreach user
+    override def getOrCreate(): SparkSession = synchronized { // TODO session => one foreach user
 
       var session: SparkSession = null
 
@@ -276,6 +277,13 @@ object XDSession {
 
       return session
     }
+
+    /**
+      * Sets session user.
+      *
+      */
+    def user(userId: String): Builder = config("crossdata.security.user", userId) //TODO: Prop key in object?
+
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/session/XDSessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/session/XDSessionState.scala
@@ -61,56 +61,8 @@ class XDSessionState(
 
   // TODO override def refreshTable(tableName: String): Unit = super.refreshTable(tableName)
   // TODO override def analyze(tableName: String): Unit = super.analyze(tableName)
-   /**
-    * Logical query plan analyzer for resolving unresolved attributes and relations.
-    */
-  override lazy val analyzer: Analyzer = {
-    new Analyzer(catalog, conf) {
 
-      override lazy val batches: Seq[Batch] = Seq(
-        Batch("Substitution", fixedPoint,
-          CTESubstitution,
-          WindowsSubstitution,
-          EliminateUnions,
-          new SubstituteUnresolvedOrdinals(conf)),
-        Batch("Resolution", fixedPoint,
-          ResolveTableValuedFunctions ::
-            ResolveRelations ::
-            ResolveReferences ::
-            ResolveCreateNamedStruct ::
-            ResolveDeserializer ::
-            ResolveNewInstance ::
-            ResolveUpCast ::
-            ResolveGroupingAnalytics ::
-            ResolvePivot ::
-            ResolveOrdinalInOrderByAndGroupBy ::
-            ResolveMissingReferences ::
-            ExtractGenerator ::
-            ResolveGenerate ::
-            ResolveFunctions ::
-            ResolveAliases ::
-            ResolveSubquery ::
-            ResolveWindowOrder ::
-            ResolveWindowFrame ::
-            ResolveNaturalAndUsingJoin ::
-            ExtractWindowExpressions ::
-            GlobalAggregates ::
-            ResolveAggregateFunctions ::
-            TimeWindowing ::
-            ResolveInlineTables ::
-            TypeCoercion.typeCoercionRules ++
-              extendedResolutionRules : _*),
-        Batch("Nondeterministic", Once,
-          PullOutNondeterministic),
-        Batch("UDF", Once,
-          HandleNullInputsForUDF),
-        Batch("FixNullability", Once,
-          FixNullability),
-        Batch("Cleanup", fixedPoint,
-          CleanupAliases)
-      )
-
-      /* TODO old rules => override lazy val batches: Seq[Batch] = Seq(
+      /* TODO (ANALYZER) old rules => override lazy val batches: Seq[Batch] = Seq(
         Batch("Substitution", fixedPoint,
           CTESubstitution,
           WindowsSubstitution),
@@ -141,15 +93,7 @@ class XDSessionState(
           CleanupAliases)
       )*/
 
-      override val extendedResolutionRules =
-        AnalyzeCreateTable(sparkSession) ::
-          PreprocessTableInsertion(conf) ::
-          new FindDataSourceTable(sparkSession) ::
-          DataSourceAnalysis(conf) ::
-          (if (conf.runSQLonFile) new ResolveDataSource(sparkSession) :: Nil else Nil)
-        }
-      }
-      /* TODO old rules => override val extendedResolutionRules =
+      /* TODO (ANALYZER) old rules => override val extendedResolutionRules =
         ResolveAggregateAlias ::
           ResolveReferencesXD(conf) ::
           ExtractPythonUDFs ::

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/XDSessionIT.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/XDSessionIT.scala
@@ -49,16 +49,7 @@ class XDSessionIT extends SharedXDSession {
 
     result should have length 5
   }
-/*
-  it must "return a XDDataFrame when executing a SQL query" in {
 
-    val df: DataFrame = xdContext.createDataFrame(xdContext.sparkContext.parallelize((1 to 5).map(i => Row(s"val_$i"))), StructType(Array(StructField("id", StringType))))
-    df.registerTempTable("records")
-
-    val dataframe = xdContext.sql("SELECT * FROM records")
-    dataframe shouldBe a[XDDataFrame]
-  }
-*/
 /*
   it must "plan a PersistDataSource when creating a table " in {
     val dataframe = xdContext.sql(s"CREATE TABLE jsonTable USING org.apache.spark.sql.json OPTIONS (path '${Paths.get(getClass.getResource("/core-reference.conf").toURI()).toString}')")

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/XDSessionIT.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/XDSessionIT.scala
@@ -60,7 +60,7 @@ class XDSessionIT extends SharedXDSession with ScalaFutures {
     val sessionsFuture: Future[Seq[XDSession]] = Future.sequence {
       (1 to 10) map { _ =>
         Future {
-          XDSession.builder.master("local[1]").newUserSession("pablo")
+          XDSession.builder.master("local[1]").create("pablo")
         }
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <derby.version>10.10.1.1</derby.version>
         <jackson4s.version>3.2.10</jackson4s.version>
         <mockito.version>1.10.19</mockito.version>
-        <common.utils.version>0.8.0-SNAPSHOT</common.utils.version>
+        <common.utils.version>0.8.0</common.utils.version>
         <guava.version>18.0</guava.version>
         <curator.version>3.2.0</curator.version>
         <crossdata-auth-iface.version>0.1.0</crossdata-auth-iface.version>


### PR DESCRIPTION
## Description

This PR provides a way of building Crossdata sessions without Spark's `getOrElse` and requiring the user associated with it. Besides, it adds a session id generation in the session constructor which remove the responsibility of generating it from the client.

Additionally 

### Testing
- [x] Unit test: Be able to create several sessions from different threads in the same process. All of these sessions acquiring unique ids.