### PR TITLE
[CROSSDATA-849][SPARK 2.1] Keep XDDataFrameFunctions

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/crossdata/XDDatasetFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/XDDatasetFunctions.scala
@@ -30,6 +30,8 @@ import scala.collection.mutable.BufferLike
 import scala.collection.{GenTraversableOnce, immutable, mutable}
 import scala.reflect.ClassTag
 
+object XDDatasetFunctions extends XDDatasetFunctions
+
 trait XDDatasetFunctions {
 
   implicit def dataset2xddataset[T : ClassTag](ds: Dataset[T]): XDDataset[T] = new XDDataset[T](ds)

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/Person.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/Person.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.crossdata
+
+case class Person (name:String, age:Int)
+
+


### PR DESCRIPTION
## Description
This PR check that all functions now are accessible from xddataset, like native collect. 
### Testing
- [x] Unit, integration tests

### Documentation
- [x] Changelog update

