### PR TITLE
[CROSSDATA-858] Wiring custom XDSessionCatalog into XDSession

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalyst/catalog/XDSessionCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalyst/catalog/XDSessionCatalog.scala
@@ -1,0 +1,21 @@
+package org.apache.spark.sql.crossdata.catalyst.catalog
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.catalyst.CatalystConf
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
+import org.apache.spark.sql.catalyst.catalog.{ExternalCatalog, FunctionResourceLoader, GlobalTempViewManager, SessionCatalog}
+
+class XDSessionCatalog(
+                        externalCatalog: ExternalCatalog,
+                        globalTempViewManager: GlobalTempViewManager,
+                        functionResourceLoader: FunctionResourceLoader,
+                        functionRegistry: FunctionRegistry,
+                        conf: CatalystConf,
+                        hadoopConf: Configuration) extends SessionCatalog(
+  externalCatalog,
+  globalTempViewManager,
+  functionResourceLoader,
+  functionRegistry,
+  conf,
+  hadoopConf
+)

--- a/core/src/main/scala/org/apache/spark/sql/crossdata/session/XDSessionState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/session/XDSessionState.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.crossdata.XDSession
 import org.apache.spark.sql.crossdata.catalyst.ExtractNativeUDFs
+import org.apache.spark.sql.crossdata.catalyst.catalog.XDSessionCatalog
 import org.apache.spark.sql.crossdata.execution.XDQueryExecution
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution._
@@ -40,7 +41,6 @@ class XDSessionState(
 
   // TODO override val conf: SQLConf = _
   // TODO override val functionRegistry: FunctionRegistry = _
-  // TODO override val catalog: SessionCatalog = _
   // TODO override val udf: UDFRegistration = _
   // TODO override val analyzer: Analyzer = _
   // TODO override val optimizer: Optimizer = _
@@ -48,6 +48,15 @@ class XDSessionState(
 
   // TODO override def planner: SparkPlanner = super.planner
   // TODO is needed?? def executeSql(sql: String): QueryExecution = executePlan(sqlParser.parsePlan(sql))
+
+  override lazy val catalog: SessionCatalog = new XDSessionCatalog(
+    sparkSession.sharedState.externalCatalog,
+    sparkSession.sharedState.globalTempViewManager,
+    functionResourceLoader,
+    functionRegistry,
+    conf,
+    newHadoopConf()
+  )
 
   override def executePlan(plan: LogicalPlan): QueryExecution = {
     /*val catalogIdentifier: String = Try(xdConfig.getString(CatalogPrefixConfigKey)).recover {


### PR DESCRIPTION
## Description

Through XDSessionState, our custom session catalog overrides default Spark 2.1 implementation thus enabling a point of extension.
