### PR TITLE
[DCS-2033] Fixed crash when pristine zookeeper backends were asked to list tables

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/crossdata/catalyst/catalog/persistent/zookeeper/ZookeeperCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/crossdata/catalyst/catalog/persistent/zookeeper/ZookeeperCatalog.scala
@@ -76,7 +76,8 @@ class ZookeeperCatalog(settings: TypesafeConfigSettings)
   private def listCatalogEntities[M <: CatalogEntityModel : Manifest](
                                                                        implicit daoContainer: DaoContainer[M]
                                                                      ): Seq[M] = lockObject.synchronized {
-    daoContainer.daoComponent.dao.getAll().get
+    if(!daoContainer.daoComponent.dao.existsPath.get) Seq.empty
+    else daoContainer.daoComponent.dao.getAll().get
   }
 
   private def getDBName(databaseModel: DatabaseModel): String = databaseModel.db.name

--- a/core/src/test/scala/org/apache/spark/sql/crossdata/XDSessionIT.scala
+++ b/core/src/test/scala/org/apache/spark/sql/crossdata/XDSessionIT.scala
@@ -86,6 +86,9 @@ class XDSessionIT extends SharedXDSession with ScalaFutures {
     val sessionA = xdSession("user01")
     val sessionB = xdSession("user02")
 
+    sessionA.catalog.listTables().count() shouldBe 0
+    sessionB.catalog.listTables().count() shouldBe 0
+
     sessionA.catalog.createExternalTable("foo", "src/test/resources/foo.json", "json")
     sessionB.catalog.tableExists("foo") shouldBe true
 


### PR DESCRIPTION
## Description

These changes protect against failures when listing tables in new environment where no catalog entities were previously created.

### Testing
- [x] Unit, integration tests